### PR TITLE
Fix typos and numbering across blog posts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -173,7 +173,12 @@
 
 [[redirects]]
   from = "/post/python_environment_config"
-  to = "/blog/python-environmint-configuration"
+  to = "/blog/python-environment-configuration"
+  status = 301
+
+[[redirects]]
+  from = "/blog/python-environmint-configuration"
+  to = "/blog/python-environment-configuration"
   status = 301
 
 [[redirects]]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "villoro",
-  "version": "2.6.9",
+  "version": "2.6.10",
   "description": "My personal website",
   "author": "Arnau Villoro <arnau@villoro.com>",
   "license": "MIT",

--- a/src/content/blog/-index.md
+++ b/src/content/blog/-index.md
@@ -1,5 +1,5 @@
 ---
 title: Blog
 meta_title: Blog
-description: TODO XXX
+description: Thoughts on programming, data engineering, and technology
 ---

--- a/src/content/blog/0002-black.mdx
+++ b/src/content/blog/0002-black.mdx
@@ -17,6 +17,10 @@ draft: false
   **Disclaimer:** A lot has changed since I wrote this. Even though `black` still works, I suggest using `ruff` instead. See <FancyLink linkText="Exploring Astral's Fast Python Tools: uv and ruff" url="https://villoro.com/blog/astral-tools-uv-and-ruff/" dark="true"/>. I'm keeping this here for reference.
 </Notice>
 
+## 0. Intro
+
+`Black` is a Python formatter that automatically enforces a consistent style. Here you'll see what it offers and how to use it.
+
 ## 1. What is black
 
 <FancyLink linkText="Black" url="https://github.com/ambv/black" company="github" dark="true"/> is a python code formatter that allows developers to focus on code itself. You can try it online at <FancyLink linkText="Black playground" url="https://black.now.sh/" company="default" dark="true"/>.

--- a/src/content/blog/0015-aws_lambda.mdx
+++ b/src/content/blog/0015-aws_lambda.mdx
@@ -10,6 +10,10 @@ tags: [Python, AWS]
 draft: false
 ---
 
+## 0. Overview
+
+AWS Lambda lets you run code without managing servers. Here we use it to start and stop EC2 and RDS instances on demand.
+
 ## 1. Intro to AWS Lambdas
 
 AWS Lambda is a compute service that lets you run code without provisioning or managing servers. AWS Lambda executes your code only when needed and scales automatically, from a few requests per day to thousands per second.

--- a/src/content/blog/0030-cmder.mdx
+++ b/src/content/blog/0030-cmder.mdx
@@ -15,7 +15,7 @@ draft: false
 **Cmder** is a software package created out of pure frustration over the absence of nice console emulators on Windows.
 It is based on amazing software, and spiced up with the Monokai color scheme and a custom prompt layout, looking sexy from the start.
 
-## 1. Instalation
+## 1. Installation
 
 You can download from the <FancyLink linkText="Cmder" url="https://cmder.app/"/>.
 I advise you install the version with git.

--- a/src/content/blog/0033-python_environment_config.mdx
+++ b/src/content/blog/0033-python_environment_config.mdx
@@ -1,5 +1,5 @@
 ---
-slug: python-environmint-configuration
+slug: python-environment-configuration
 title: Setting up a Python environment
 meta_title: Setting up a Python environment
 description: Learn how to properly set up a python development environment with all the useful tools you can use as well as some good tips to work as a pro.

--- a/src/content/blog/0050-small_files.mdx
+++ b/src/content/blog/0050-small_files.mdx
@@ -1,7 +1,7 @@
 ---
 slug: solving-problem-small-files-data-lake
-title: Solving the probem with small files in the Data Lake
-meta_title: Solving the probem with small files in the Data Lake
+title: Solving the problem with small files in the Data Lake
+meta_title: Solving the problem with small files in the Data Lake
 description: This post addresses the common problem of small files in data lakes, which can lead to significant performance degradation and increased costs. It provides an in-depth guide on understanding the issues caused by small files, determining optimal file sizes, and effectively managing file sizes using tools like Apache Spark, AWS Athena, Delta Lake, and Apache Iceberg. The post also covers strategies for tracking file sizes and partitioning tables to optimize data processing and storage efficiency.
 date: 2024-10-23
 image: "/images/blog/0050-handling-small-files.jpg"
@@ -66,7 +66,7 @@ Similarly, the <FancyLink linkText="DuckDB | Parquet File Sizes" url="https://du
 The key to avoiding small files in your data lake is to control the number of files written during data processing.
 Ensuring that the files are of optimal size improves both performance and cost-efficiency.
 
-### 3.2. Spark
+### 3.1. Spark
 
 In Spark, you can control the number of files written by using the `sdf.repartition(n_files)` function, which allows you to specify the number of partitions (and hence the number of output files).
 Additionally, you can configure Spark to manage the size of files by setting the minimum and maximum number of rows per file through the configuration options `spark.sql.files.maxRecordsPerFile` and `spark.sql.files.minRecordsPerFile`.
@@ -76,7 +76,7 @@ Additionally, you can configure Spark to manage the size of files by setting the
   The number of partitions also affects Spark's parallelization; too few partitions can lead to underutilized resources, while too many can cause excessive overhead.
 </Notice>
 
-### 3.3. Athena with DBT
+### 3.2. Athena with DBT
 
 <Notice type="warning">
   In AWS Athena, **there is no direct way to control the number of files** written during query execution.


### PR DESCRIPTION
## Summary
- fill blog index description
- fix slug typo in Python environment config post
- correct problem typo and numbering in small files post
- fix installation heading spelling
- add intro sections to Black and AWS Lambda posts

## Testing
- `npx prettier -w src/content/blog/-index.md src/content/blog/0030-cmder.mdx src/content/blog/0033-python_environment_config.mdx src/content/blog/0050-small_files.mdx src/content/blog/0002-black.mdx src/content/blog/0015-aws_lambda.mdx`

------
https://chatgpt.com/codex/tasks/task_b_684ae9f3a6b88328b0f96eb7937e86c3