### PR TITLE
Remove hardcoded numeric prefixes from blog headings

### DIFF
--- a/src/content/blog/0004-colors.mdx
+++ b/src/content/blog/0004-colors.mdx
@@ -12,7 +12,7 @@ draft: false
 
 <script type="module" src="/js/posts/0004-plots-colors.js"></script>
 
-## 0. Intro
+## Intro
 
 Choosing between colors is always a difficult task, especially for people like me who are not very good at design tasks.
 
@@ -20,7 +20,7 @@ I used to have a hard time every time I had to deal with colors. I always felt t
 
 But in 2014 Google presented <FancyLink linkText="Material Design" url="https://material.io/"/> and a very good <FancyLink linkText="Color palette" url="https://material.io/design/color/the-color-system.html#color-usage-palettes" company="material"/>.
 
-## 1. Material design palette
+## Material design palette
 
 There are 19 colors with 10 different intensities for each one plus the white and black colors. This gives us 192 different colors ordered in a matrix.
 
@@ -32,7 +32,7 @@ This allows us to use gradients of the same colors like in the following plot:
 
 More info about colors and palettes can be found at <FancyLink linkText="HTML Color codes" url="https://htmlcolorcodes.com/color-chart/"/>.
 
-## 2. Using material colors in python (vpalette)
+## Using material colors in python (vpalette)
 
 I use <FancyLink linkText="Plotly" url="https://plotly.com/"/> in a lot of projects and I like using the material colors as well.
 
@@ -62,7 +62,7 @@ Remember to install it using pip with:
 pip install vpalette
 ```
 
-### 2.1. Flat colors
+### Flat colors
 
 If you use vpalette you can also use the <FancyLink linkText="Flat colors" url="https://htmlcolorcodes.com/color-chart/flat-design-color-chart/"/>.
 

--- a/src/content/blog/0005-strings_python.mdx
+++ b/src/content/blog/0005-strings_python.mdx
@@ -10,13 +10,13 @@ tags: [Python, Best Practices]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 There are a lot of ways to work with strings in Python. And there are some cool tricks I want to share that will make it easier to deal with strings.
 
-## 1. Formatting strings
+## Formatting strings
 
-### 1.1. Raw strings with `r" "`
+### Raw strings with `r" "`
 
 This allows you to have a literal string without escaping characters or special ones.
 
@@ -39,7 +39,7 @@ r"C:\some\name"
   ame
 </TerminalOutput>
 
-### 1.2. Formatting with repeated occurrences
+### Formatting with repeated occurrences
 
 You can use `"".format()` and use names for each text that you want to insert. For example:
 
@@ -63,7 +63,7 @@ print("""
 > [!tip]
 > Triple quotation marks (`"""`) allows to have more than one line in a string
 
-### 1.3. Formatting with `f" "` (Python 3.6+)
+### Formatting with `f" "` (Python 3.6+)
 
 Imagine you have the following filename `src/data/2019-02-16.xlsx`. The best way to get the filename giving the following parameters:
 
@@ -95,9 +95,9 @@ filename = "{}/{:%Y-%m-%d}.xlsx".format(path, mdate)
 
 All give the same result but with `f" "` it is more compact and easier to read.
 
-## 2. Concatenating strings
+## Concatenating strings
 
-### 2.1. Concat few strings
+### Concat few strings
 For small concatenations you can simply put two strings together:
 
 ```python
@@ -116,7 +116,7 @@ You can also repeat strings with:
   \> "hello_hello_hello_hello_"
 </TerminalOutput>
 
-### 2.2. Concat a lot of strings
+### Concat a lot of strings
 
 To concatenate strings you should work with lists and join them at the end. It's faster and cleaner.
 
@@ -143,7 +143,7 @@ for x in mlist:
   105 µs ± 3.92 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
 </TerminalOutput>
 
-## 3. Slicing strings
+## Slicing strings
 
 ```python
 text = "hello world"
@@ -155,7 +155,7 @@ text[-5: -1]:     "worl"
 text[1:-1]:       "ello worl"
 ```
 
-## 4. String builtin functions
+## String builtin functions
 
 `Upper`, `lower` and `title` functions:
 

--- a/src/content/blog/0006-singleton.mdx
+++ b/src/content/blog/0006-singleton.mdx
@@ -10,11 +10,11 @@ tags: [Python]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 Python classes are very useful but sometimes they lack some features that might be very useful.
 
-## 1. The problem
+## The problem
 Let's imagine you want to create a class that has some data. This class will also have a sync function to update the data. As an example let's create two loader instances of the same class.
 
 ```python
@@ -53,7 +53,7 @@ loader2.get_value()
 
 If what you need is to use this data in multiple python files and you want to only call the sync function once and not in every python file this won't work as expected.
 
-## 2. The singleton pattern
+## The singleton pattern
 What is needed is a class that can only have **one instance**. This is the singleton (more info at <FancyLink linkText="Python3 patterns and idioms" url="https://python-3-patterns-idioms-test.readthedocs.io/en/latest/Singleton.html" company="readthedocs"/>). The simplest way to achieve that is by creating a new Python file since by design it will be unique.
 
 So for example let's create `single_loader.py`.
@@ -99,13 +99,13 @@ single_loader2.get_value()
   \> 1
 </TerminalOutput>
 
-### 2.1. One real example
+### One real example
 
 While I was working with one of my <FancyLink linkText="Dash" url="https://plot.ly/products/dash/" company="plotly"/> projects I made use of that to create a `data_loader.py` file. You can view the code <FancyLink linkText="Expensor personal" url="https://github.com/villoro/expensor_personal/tree/4.3.3/src" dark="true"/>.
 
 What I have is a `data_loader.py` that implements a `sync` function to update both `DFS` and `YML` vars. Those two vars are then used in all files inside the `pages` folder. And the `sync` function of the `data_loader.py` is only called in `index.py/update_sync_count()`.
 
-## 3. Another option: Using class variables
+## Another option: Using class variables
 As pointed out by **Gustau** in the comments there is another way to do it using classes.
 
 ```python
@@ -142,7 +142,7 @@ loader2.get_value()
   \> 1
 </TerminalOutput>
 
-### 3.1. Mixing the two methods
+### Mixing the two methods
 
 Be careful, you probably don't want to mix both types of variable assignments because it can yield unexpected results. Let's take the following example:
 

--- a/src/content/blog/0007-blog_basic_tools.mdx
+++ b/src/content/blog/0007-blog_basic_tools.mdx
@@ -10,7 +10,7 @@ tags: [Web, Tools, Setup]
 draft: false
 ---
   
-## 0. Why?
+## Why?
 
 If you just created a blog you will probably want to have common and useful features like:
 
@@ -24,7 +24,7 @@ In this post I am going to explain how to use **Google Analytics** to track visi
 
 It won't be a step by step guide, instead I will highlight the things I think are more relevant.
 
-## 1. Google Analytics
+## Google Analytics
 You should first register your web page and then copy and paste at the scripts part of your base template the code they provide.
 
 One thing I believe is really important is to **filter out your own traffic** to the webpage while you are developing or testing. In my case I did a filter to check if the host of the page is the bare domain of my page. This way I will effectively exclude visits from `localhost` or testing branches like `develop.villoro.com`.
@@ -54,7 +54,7 @@ Other ways of filtering the traffic would be:
 * <FancyLink linkText="Using IP filters" url="https://support.google.com/analytics/answer/1034840?hl=en"/>. You will need a static IP for every computer you use to develop.
 * Using cookies.
 
-## 2. Mailchimp
+## Mailchimp
 This service is the one that involves less code. Setting it up can be done through their webpage after signing up. I recommend that you customize some things:
 
 * Sign up form. There you will also get the URL that you will use in your site.
@@ -68,7 +68,7 @@ When you have finished that you can put a button in your page so that people can
 </a>
 ```
 
-## 3. Disqus
+## Disqus
 Setting up Disqus is really easy. You only need to register and then copy and paste two code parts. The first one will be the div with the comments:
 
 ```html

--- a/src/content/blog/0008-static_webpage.mdx
+++ b/src/content/blog/0008-static_webpage.mdx
@@ -10,14 +10,14 @@ tags: [Python, Web, Tutorial, Setup]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 Here you can learn how to create a static webpage using Flask.
 Check the full example on <FancyLink linkText="Github" url="https://github.com/villoro/villoro_posts/tree/master/016-static_webpage" dark="true"/>.
 
 You only need some **html** knowledge.
 
-## 1. Install requirements
+## Install requirements
 
 Run:
 
@@ -34,7 +34,7 @@ oyaml: to work with ordered yamls
 pygments: to display beautiful code snippets when transforming markdown
 ```
 
-## 2. html templates
+## html templates
 The first thing you will need are some `html` templates. I suggest that you use at least one `base.html` as the basic template and then other templates for each page.
 
 The `base.html` file should have the basic structure, for example:
@@ -84,7 +84,7 @@ Then we can create the `about.html` page template using:
 > `{{ title }}` and `{{ description }}` are parameters that we will pass to the flask template.
 
 
-## 3. Flask app and freezer
+## Flask app and freezer
 
 The `index.py` will be the actual `Flask` app. It will only render the templates.
 
@@ -128,7 +128,7 @@ if __name__ == "__main__":
 
 Now if you run `python src/freeze.py` you will create the folder `src/build` with the static webpage.
 
-## 4. Using yamls
+## Using yamls
 In order to make it easier to customize the pages I suggest using `yaml` files. They are like `json` files but more compact.
 
 For example you can create the file `about.yaml` with:
@@ -179,7 +179,7 @@ if __name__ == "__main__":
     APP.run(debug=True)
 ```
 
-## 5. css and images
+## css and images
 To use custom `css` files and/or images simply place them in the folder `src/static/`. For using them you can:
 
 ```html
@@ -190,7 +190,7 @@ To use custom `css` files and/or images simply place them in the folder `src/sta
 <img src="/static/image.jpg" alt="image"/>
 ```
 
-## 6. Hosting the webpage
+## Hosting the webpage
 
 I strongly recommend using <FancyLink linkText="Netlify" url="https://www.netlify.com/"/> since they do a lot of things for free. Some of them you probably didn't know that you should do them (or at least I didn't).
 

--- a/src/content/blog/0009-aws_ec2.mdx
+++ b/src/content/blog/0009-aws_ec2.mdx
@@ -10,11 +10,11 @@ tags: [AWS, Tutorial, Setup]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 Amazon is one of the most important infrastructure services provider. This includes computing power, storage, networking and databases among the a lot of others. One of the computing service that it offers are the **EC2** instances. In this post I am going to explain how to set up an Ubuntu server using an EC2 instance.
 
-## 1. Create an EC2 instance
+## Create an EC2 instance
 
 First of all go to <FancyLink linkText="AWS console" url="https://aws.amazon.com/" company="aws"/> and log in. From there it is important to select the **Region** where you want your services. You should select somewhere that is close to the locations that will receive most traffic. In my case I will use `UE (London)` since is close to where I live.
 
@@ -40,17 +40,17 @@ For the configuration of the instance I suggest the following:
 > [!warning]
 > Some people have a **dynamic IP**. If this is your case and you have restricted the access to the instance you should update periodically the Security Group so that you can always access the instance.
 
-## 2. Accessing the instance
+## Accessing the instance
 You can access your instance through an SSH connection. I suggest using the open source <FancyLink linkText="PuTTY" url="https://www.putty.org/" company="default" dark="true"/>.
 
-### 2.1. Transform pem to ppk
+### Transform pem to ppk
 After installing PuTTY open `PuTTYgen` to transform the `.pem` file with the key to a `.ppk`.
 
 1. Select load and import the `.pem` file.
 2. Select `Save private key` and store the `ppk` file.
 3. Open the `ppk` file key so that it gets loaded into PuTTY.
 
-### 2.2. Access the EC2 with SSH
+### Access the EC2 with SSH
 1. From the AWS console at the EC2 page find the public IP of the instance you just created (The format should be XX.XXX.XXX.XXX where X are numbers).
 2. Write that IP into PuTTY and do not change the port (22).
 3. Select `Open`
@@ -58,12 +58,12 @@ After installing PuTTY open `PuTTYgen` to transform the `.pem` file with the key
 5. Log in using `ubuntu` as user. The key you just imported should serve as password (you should not write anything)
 
 
-## 3. Do something with the instance
+## Do something with the instance
 If you did all the above correctly you should have a fully working `Ubuntu` instance and a connection with PuTTY through `SSH`.
 
 From here you can do whatever you want with it.
 
-### 3.1. Set up python (Optional)
+### Set up python (Optional)
 Since I use python in almost every project I will include how to set it up.
 
 First check that you have python 3 installed with the command:

--- a/src/content/blog/0010-airflow.mdx
+++ b/src/content/blog/0010-airflow.mdx
@@ -10,18 +10,18 @@ tags: [Tools, Orchestration, Tutorial, Setup]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 Apache Airflow is a platform to programmatically author, schedule and monitor workflows. The airflow scheduler executes your tasks on an array of workers following the specified dependencies.
 
-## 1. Why Airflow?
+## Why Airflow?
 People usually need to execute some tasks periodically. One common solution is to use <FancyLink linkText="Cron" url="https://es.wikipedia.org/wiki/Cron_(Unix)" dark="true"/> which is a good solution for simple tasks. But the more tasks you need to schedule the more problems you will have, especially if there are dependencies between one another.
 
 Airflow allows to define workflows of tasks and you can define them as code making it more maintainable, versionable, testable and collaborative.
 Check out the <FancyLink linkText="Airflow documentation" url="https://airflow.apache.org/" company="airflow"/> for more information.
 
 
-## 2. Installation
+## Installation
 First of all you will need a Linux machine. I'd suggest you use an **AWS EC2** instance.
 You can see <FancyLink linkText="Creating EC2 instances in AWS" url="https://villoro.com/blog/creating-ec2-aws/" dark="true"/> how to create one.
 
@@ -35,7 +35,7 @@ When it is installed you can initialize the database (it will be SQLite by defau
 airflow initdb
 ```
 
-### 2.1 Test Airflow
+### Test Airflow
 We will test airflow with an example from <FancyLink linkText="Airflow documentation" url="https://airflow.apache.org/tutorial.html" company="airflow"/>. You will need to create the file `tutorial.py`:
 
 ```sh
@@ -110,7 +110,7 @@ You can test that things are going as expected if the following command does not
 python3 ~/airflow/dags/tutorial.py
 ```
 
-#### 2.1.1. Validate metadata
+#### Validate metadata
 You can check that the tutorial dag has been properly created with:
 
 ```sh
@@ -124,7 +124,7 @@ airflow list_tasks tutorial
 airflow list_tasks tutorial --tree
 ```
 
-#### 2.1.2 Run the test
+#### Run the test
 You can launch tasks with the following commands:
 
 ```sh
@@ -140,7 +140,7 @@ airflow test tutorial sleep 2015-06-01
 airflow test tutorial templated 2015-06-01
 ```
 
-## 3. Use Airflow UI
+## Use Airflow UI
 
 Of the great things about airflow is the <FancyLink linkText="Airflow UI" url="https://airflow.apache.org/ui.html" company="airflow"/>.
 
@@ -150,14 +150,14 @@ Of the great things about airflow is the <FancyLink linkText="Airflow UI" url="h
 
 ![Airflow Grid](../../images/posts/2019/0010-airflow_grid.png)
 
-### 3.1. Open EC2 ports (optional)
+### Open EC2 ports (optional)
 If you are using an **AWS EC2** you will probably have only the 22 port open to connect through SSH.
 
 1. Go to AWS console and then to the EC2 page. Use the sidebar to go to `NETWORK & SECURITY/Security Groups`.
 2. Find the security group of your EC2 instance and edit the **Inbound** rules.
 3. Add `Custom TCP Rule` with port `8080`.
 
-### 3.2. Start Airflow
+### Start Airflow
 You can start airflow with:
 
 ```sh
@@ -166,7 +166,7 @@ airflow webserver -p 8080 # or simply use 'airflow webserver'
 
 You can now view Airflow at `XX.XXX.XXX.XXX:8080` (Use your EC2 IP).
 
-### 3.3. Secure Airflow UI
+### Secure Airflow UI
 First we will edit the airflow configuration.
 
 ```sh
@@ -209,11 +209,11 @@ session.close()
 exit()
 ```
 
-## 4. Running airflow with supervisor
+## Running airflow with supervisor
 
 If you want a process always running and to be restarted on failure you should use **supervisor**.
 
-### 4.1. Clean examples and other tests
+### Clean examples and other tests
 
 Edit the `airflow.cfg` to disable the examples by editing `load_examples = True` to:
 
@@ -242,7 +242,7 @@ pkill -f airflow
 > [!warning]
 > This will delete the current **DAG** information
 
-### 4.2. Running supervisor
+### Running supervisor
 
 First install it with:
 
@@ -296,14 +296,14 @@ sudo supervisorctl status
 
 And that's it. You can now start using airflow.
 
-## 5. Next steps
+## Next steps
 
 You can add **DAG**s in the folder `~/airflow/dags` and they should be automatically loaded. 
 
 > [!tip]
 > It is advised to run airflow with at least a `t2.medium` **AWS instance**. You can run it with a smaller one (I use a `t2.micro` since it is in the free tier) but you can easily get your instance at 100% CPU usage while running tasks.
 
-### 5.1. Using git
+### Using git
 You can even change that path to a folder that is tracked with git to keep control of the **DAG**s by editing the `airflow.cfg`:
 
 <TerminalOutput color="stone">

--- a/src/content/blog/0011-nginx_gunicorn.mdx
+++ b/src/content/blog/0011-nginx_gunicorn.mdx
@@ -10,11 +10,11 @@ tags: [Python, Web]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 In order to serve a python web app hosted on a server there are some tools that you need to install and set up.
 
-## 1. Basic schema
+## Basic schema
 First of all you will need a Linux machine. I'd suggest you use an **AWS EC2** instance. You can see <FancyLink linkText="Creating EC2 instances in AWS" url="https://villoro.com/blog/creating-ec2-aws/" dark="true"/> how to create one.
 
 There are three main components needed for serving a python app:
@@ -26,30 +26,30 @@ There are three main components needed for serving a python app:
 
 ![Architecture diagram](../../images/posts/2019/0011-nginx_gunicorn.jpg)
 
-### 1.1 Web server
+### Web server
 This component will handle the requests and among other things it will deal with static files (images, css, js...).
 In this post we are going to use <FancyLink linkText="Nginx" url="https://www.nginx.com/"/> since it is more commonly used for python.
 Another popular option is <FancyLink linkText="Httpd" url="https://httpd.apache.org/" company="httpd"/>.
 
-### 1.2. WSGI
+### WSGI
 Web servers cannot communicate directly with python apps so you need a Web Server Gateway Interface (<FancyLink linkText="WSGI" url="https://wsgi.readthedocs.io/en/latest/what.html" company="readthedocs"/>).
 In this case we will use <FancyLink linkText="Gunicorn" url="https://gunicorn.org/"/> because it is a simple solution.
 Another common choice would be <FancyLink linkText="Uwsgi" url="https://uwsgi-docs.readthedocs.io/en/latest/" company="readthedocs"/>.
 
-### 1.3. Python App
+### Python App
 The idea of this post is to set up `nginx` and `gunicorn`. To test them you can create a very simple app using <FancyLink linkText="Flask" url="http://flask.pocoo.org/" company="flask"/>. You can do the same with <FancyLink linkText="Django" url="https://www.djangoproject.com/"/> or <FancyLink linkText="Dash" url="https://plot.ly/products/dash/" company="plotly"/> apps.
 
-### 1.4. Supervisor
+### Supervisor
 <FancyLink linkText="Supervisor" url="http://supervisord.org/" company="default" dark="true"/> is a system that allows users to monitor and control processes. This will make sure to restart the gunicorn process if anything goes wrong. Without it you should do it yourself.
 
 > [!info]
 > You can read more about <FancyLink linkText="Why a web server and wsgi" url="https://serverfault.com/questions/331256/why-do-i-need-nginx-and-something-like-gunicorn"/>.
 
 
-## 2. Installation
+## Installation
 First you should create the flask app and test it. After you will install and configure both wsgi and supervisor in order to have a service to serve the app. Finally you will configure nginx to serve the content to the web. 
 
-### 2.1. Python app
+### Python app
  First let's create the `index.py` with the app:
 
 ```sh
@@ -92,7 +92,7 @@ You can now view it by going at `XX.XXX.XXX.XXX:PORT` (Use your EC2 IP and the p
 > [!tip]
 > Default flask port is **5000**. To try it you need to open the port.
 
-#### 2.1.1. Open EC2 ports (optional)
+#### Open EC2 ports (optional)
 If you are using an **AWS EC2** it is possible that you don't have the port 80 opened. You can do it with:
 
 1. Go to AWS console and then to the EC2 page. Use the sidebar to go to `NETWORK & SECURITY/Security Groups`.
@@ -100,7 +100,7 @@ If you are using an **AWS EC2** it is possible that you don't have the port 80 o
 3. Add `Custom TCP Rule` with port `5000` (or the one you used).
 4. If you are opening a port for testing, remember to close it back when you are done.
 
-### 2.2. WSGI
+### WSGI
 
 Install gunicorn with:
 
@@ -108,7 +108,7 @@ Install gunicorn with:
 pip3 install gunicorn
 ```
 
-### 2.3 Install supervisor
+### Install supervisor
 
 ```sh
 sudo apt install supervisor -y
@@ -146,9 +146,9 @@ sudo service supervisor restart
 sudo supervisorctl status
 ```
 
-### 2.4. Web server
+### Web server
 
-#### 2.4.1. Install and test nginx
+#### Install and test nginx
 
 To install nginx run:
 ```sh
@@ -163,7 +163,7 @@ You can now view if nginx is serving content by going at XX.XXX.XXX.XXX (Use you
 > [!warning]
 > You will need the port **80** opened
 
-#### 2.4.2 Configure nginx
+#### Configure nginx
 
 You should add a config file for your app (`flask_test` for example) inside the nginx `sites-available` folder. You should delete the `default` config file.
 
@@ -209,9 +209,9 @@ You can now go to `XX.XXX.XXX.XXX` and you should see the flask app `Hello World
 > [!tip]
 > If everything is working remember to close the ports that you opened only for testing.
 
-## 3. Next steps
+## Next steps
 
-### 3.1. Configure nginx
+### Configure nginx
 
 The nginx configuration you used is really simple. For example you can set nginx to serve static files directly instead of passing through the flask app by:
 
@@ -234,7 +234,7 @@ server {
 
 For more info about <FancyLink linkText="How to configure nginx" url="https://www.linode.com/docs/web-servers/nginx/how-to-configure-nginx/"/>.
 
-### 3.2. SSL certificate
+### SSL certificate
 
 I strongly suggest you set up a SSL certificate for apps that are in production.
 You can learn how with <FancyLink linkText="How to secure nginx with let's encrypt" url="https://www.digitalocean.com/community/tutorials/how-to-secure-nginx-with-let-s-encrypt-on-ubuntu-18-04"/>.

--- a/src/content/blog/0012-tables_format.mdx
+++ b/src/content/blog/0012-tables_format.mdx
@@ -12,11 +12,11 @@ draft: false
 
 <script type="module" src="/js/posts/0012-plots-tables-format.js"></script>
 
-## 0. Intro
+## Intro
 
 When working with **pandas** people usually need to store one or more tables. There are a lot of different formats to do that. In this post I am going to compare the performance between them.
 
-## 1. How the test will be done
+## How the test will be done
 To do the tests I downloaded 3 datasets of different sizes:
 
 <div class="flex justify-center">
@@ -36,10 +36,10 @@ The formats that I will test are:
 * pickle
 * xlsx
 
-## 2. Test 1: Simple test
+## Test 1: Simple test
 First of all I will check how they perform without changing any parameters. I will do 100 iterations with the small dataset and 10 with the medium one.
 
-### 2.1. Size small and iterations 100 with all extensions
+### Size small and iterations 100 with all extensions
 
 First of all the average reading/writing times for each format.
 
@@ -49,7 +49,7 @@ First of all the average reading/writing times for each format.
 > It seems that `xlsx` is a slow option
 
 
-### 2.2. Size medium and iterations 10 with all extensions
+### Size medium and iterations 10 with all extensions
 
 <canvas id="chart_s1_i10_time" style="width:100%;height:300px;"></canvas>
 
@@ -62,7 +62,7 @@ With the medium dataframe the results are very similar.
 
 Regarding the file size both `xlsx` and `parquet` outperform the rest. If you look the pandas documentation you will see that **all extensions except `xlsx` and `feather` allow different types of compression.** Also `parquet` uses a more aggressive compression by default. We need to test the formats and the different compressions.
 
-## 3. Test 2: Include compressions
+## Test 2: Include compressions
 
 This time each extension will be tested using all possible compressions. The results are:
 
@@ -102,7 +102,7 @@ It is not clear which formats and compressions work best. Let's plot reading/wri
 > [!warning]
 > **csv** underperforms compared to the other formats
 
-## 4. Test 3: Using the big table
+## Test 3: Using the big table
 
 For this test I will only use the best formats from the previous test. Those are:
 
@@ -139,7 +139,7 @@ With a file of this size it is clear that **parquet** is the best option. For co
 > [!success]
 > `parquet` is the best for big tables.
 
-## 5. Conclusions
+## Conclusions
 
 1. `Excel` is only useful for **small** files when you are planning to open with an Excel program.
 2. `csv` performs poorly

--- a/src/content/blog/0013-intro_machine_learning.mdx
+++ b/src/content/blog/0013-intro_machine_learning.mdx
@@ -10,11 +10,11 @@ tags: [Python, ML, Intro, Tutorial]
 draft: false
 ---
 
-## 1. What is Machine Learning?
+## What is Machine Learning?
 
 Machine Learning is an application of Artificial Intelligence (AI) that allows computers to automatically learn from data without being explicitly programmed. Instead of using explicit instructions it relies on patterns and inference instead.
 
-### 1.1. Types of Machine Learning
+### Types of Machine Learning
 
 There are different tasks that ML can perform and they can be categorized in three categories:
 
@@ -24,20 +24,20 @@ There are different tasks that ML can perform and they can be categorized in thr
 
 ![Machine Learning types](../../images/posts/2019/0013-machine_learning_types.jpg)
 
-#### 1.1.1. Supervised Learning
+#### Supervised Learning
 Supervised Learning algorithms build a mathematical model from both the inputs and the desired outputs. Each training example has one or more inputs (features, usually represented as `x`) and at least one desired output (target, represented as `y`). It will have an objective function that will be optimized through iterations (training). After the training is completed the algorithm would be able to predict the target given the features of new examples.
 
 Supervised learning algorithms include classification and regression.
 
-#### 1.1.2. Unsupervised Learning
+#### Unsupervised Learning
 
 Unsupervised learning algorithms take a set of data that contains only the inputs and find a structure. The algorithm learns from unlabeled data and is able to create groups (clusters) of similar points.
 
-#### 1.1.3. Reinforcement Learning
+#### Reinforcement Learning
 
 Reinforcement learning (RL) is an area of machine learning concerned with how software agents ought to take actions in an environment so as to maximize some notion of cumulative reward. The focus of the agent is in finding a balance between exploration (of uncharted territory) and exploitation (of current knowledge).
 
-### 1.2. Machine Learning steps
+### Machine Learning steps
 
 There are seven steps:
 
@@ -45,14 +45,14 @@ There are seven steps:
 
 In this post we will do everything except the data gathering.
 
-## 2. Full Machine Learning example
+## Full Machine Learning example
 
 As a way to help you understand what is ML we will use an example of supervised learning.
 We will use the <FancyLink linkText="Bike sharing data" url="https://www.kaggle.com/contactprad/bike-share-daily-data"/> from <FancyLink linkText="Kaggle" url="https://www.kaggle.com"/>.
 
 Bike-sharing rental process is highly correlated to the environmental and seasonal settings. For instance, weather conditions, precipitation, day of week, season, hour of the day, etc. can affect the rental behaviors. So in this example of regression we will use that information to try to predict the bike rental.
 
-### 2.1. How the data is used in a supervised learning problem
+### How the data is used in a supervised learning problem
 
 The data will be split in 3 groups:
 
@@ -64,7 +64,7 @@ The data will be split in 3 groups:
 
 The idea is to learn with **training** data. Then check the model with the **validation** data and if the results are not good tune the parameters train another time. When the results are good stop and do one final test with the **test** data.
 
-### 2.2. Preparing the data
+### Preparing the data
 
 The first thing we need to do is to handle the categorical features since machine learning algorithms don't work with text as inputs. In this dataset we have 5 categorical features:
 
@@ -85,11 +85,11 @@ Let's also check the target we want to predict. In the dataset there are the ren
 
 ![Preview target variable](../../images/posts/2019/0013-preview-target-variable.png)
 
-### 2.3. Selecting the algorithm
+### Selecting the algorithm
 
 In this example we will use Support Vector Regression (SVR). It is an algorithm that is similar to a linear regression but using a threshold. It is out of the scope of this post to explain how it works but you can read it <FancyLink linkText="Support Vector Regression Or SVR" url="https://medium.com/coinmonks/support-vector-regression-or-svr-8eb3acf6d0ff"/>.
 
-### 2.4. Training and parameter tuning
+### Training and parameter tuning
 
 First we fit the algorithm using the **training** data and we check the result using the **validation** data.
 
@@ -98,7 +98,7 @@ First we fit the algorithm using the **training** data and we check the result u
 > [!success]
 > Since the results are good there is no need to tune the parameters, the default ones work well.
 
-### 2.5. Check that the algorithm is working
+### Check that the algorithm is working
 
 Now we will use the **test** data to ensure that everything is working well.
 

--- a/src/content/blog/0014-decorators.mdx
+++ b/src/content/blog/0014-decorators.mdx
@@ -10,11 +10,11 @@ tags: [Python]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 Decorators are a really useful tool for python development but not a lot of people know what they are and how they work. In this post you are going to master them so that you can use them and create your own.
 
-## 1. Understanding functions
+## Understanding functions
 
 Before starting with decorators it is important to understand how functions work in Python. Functions have **parameters** for example:
 
@@ -38,7 +38,7 @@ def message_to_person(message, name):
 > [!tip]
 > We can pass **any** object as a parameter to a function. We can even pass a **function** as a parameter.
 
-## 2. Decorators basics
+## Decorators basics
 
 The idea behind **decorators** is to modify a function so that some things happen 'around' that function. This means before or after the function (or both).
 
@@ -94,7 +94,7 @@ wait_3_seconds_and_print()
 
 Now we have the `timeit` decorator, the `wait_3_seconds` and the `wait_3_seconds_and_print` functions. Those both will wait 3 seconds but the second one will print the execution time.
 
-## 3. Using real decorators
+## Using real decorators
 
 Now that we understand the idea behind decorators, we can rewrite the examples using real decorators. The behavior will be exactly the same.
 
@@ -160,7 +160,7 @@ hello()
   After function
 </TerminalOutput>
 
-## 4. Passing arguments to decorators
+## Passing arguments to decorators
 
 It is possible to pass arguments to `decorators`. The idea is to create another wrapper that will take the parameters. For example:
 
@@ -197,11 +197,11 @@ hello_argh()
 > [!note]
 > This decorator allows the user to decide what to print before the main function.
 
-## 5. Some cool examples
+## Some cool examples
 
 Now that we understand how decorators work, let's see some useful examples of what decorators can offer.
 
-### 5.1. supertimeit decorator
+### supertimeit decorator
 
 This is a decorator that takes one outputting function and outputs the execution time. By default it will use the `print` function.
 
@@ -260,7 +260,7 @@ wait_2_seconds_and_log()
 
 Now the function logs the time.
 
-### 5.2. infallible decorator
+### infallible decorator
 
 This decorator will prevent any function from crashing and it will show the details of any `Exception` occurred.
 
@@ -305,7 +305,7 @@ wrong_math(1)
 > [!success]
 > Now we see a message when it crashes
 
-### 5.3. Using them both
+### Using them both
 
 And the best part is that we can use `supertimeit` and `infallible` decorators together.
 

--- a/src/content/blog/0015-aws_lambda.mdx
+++ b/src/content/blog/0015-aws_lambda.mdx
@@ -10,18 +10,18 @@ tags: [Python, AWS]
 draft: false
 ---
 
-## 0. Overview
+## Overview
 
 AWS Lambda lets you run code without managing servers. Here we use it to start and stop EC2 and RDS instances on demand.
 
-## 1. Intro to AWS Lambdas
+## Intro to AWS Lambdas
 
 AWS Lambda is a compute service that lets you run code without provisioning or managing servers. AWS Lambda executes your code only when needed and scales automatically, from a few requests per day to thousands per second.
 
 AWS lambdas should be used for small and light functions. For more complicated or time expensive functions it is better to use an `EC2` instance which can be turned on/off when needed to keep costs low.
 
 
-## 2. Creating a lambda to start/stop instances
+## Creating a lambda to start/stop instances
 
 The idea is to create a lambda that can start a system (both an `EC2` and `RDS`) using an API.
 
@@ -39,13 +39,13 @@ queryStringParameters = {
 }
 ```
 
-### 2.1. How it works
+### How it works
 This lambda is created in **python 3.6** and relies on aws **boto3** library. There are 2 files:
 
 * **aws.py:** this handles the start/stop of the instances. This file is shared in all lambdas
 * **lambda_function.py:** this has the logic for deciding what to start/stop
 
-#### 2.1.1. aws.py
+#### aws.py
 First of all it will start an AWS session and it is important to start it in the correct region. There is no need to use any credentials since AWS has already put the ACCESS_KEY and SECRET_KEY as environment vars and are used in _boto3_ background.
 
 > [!warning]
@@ -62,7 +62,7 @@ The workflow is:
 * **start rds:** from 'stopped' to 'available'
 * **stop rds:** from 'available' to 'stopped'
 
-#### 2.1.2. lambda_handler.py
+#### lambda_handler.py
 
 There is a dictionary with the info of the instances that the lambdas can act upon. The idea is that users can only use the name of the system (```magento/vtiger```) and the dictionary will give the instance id.
 
@@ -102,7 +102,7 @@ If the token is correct it will iterate over the **systems** present in the requ
 }
 ```
 
-### 2.2. Create the lambda
+### Create the lambda
 First of all there is some work to do in AWS IAM service. This will give the lambdas the following permissions:
 
 1. Act on `EC2` instances
@@ -111,7 +111,7 @@ First of all there is some work to do in AWS IAM service. This will give the lam
 
 To do that first you will need to create a **policy** and then assign it to a **role**.
 
-#### 2.2.1. Create a IAM/Policy
+#### Create a IAM/Policy
 
 1. Go to AWS IAM service
 2. Create a Policy
@@ -161,7 +161,7 @@ The policy config is:
 }
 ```
 
-#### 2.2.2. Create a IAM/Role
+#### Create a IAM/Role
 
 1. Go to AWS IAM service
 2. Create a Policy
@@ -170,7 +170,7 @@ The policy config is:
     3. Select previously created policy
     4. Add name + description
 
-#### 2.2.3. Create lambda itself
+#### Create lambda itself
 
 1. Go to AWS Lambda service
 2. Go to sidebar ```functions```
@@ -186,7 +186,7 @@ The policy config is:
 5. Add tags
 6. Add environment vars for **instances_api**
 
-#### 2.2.4. Create API
+#### Create API
 
 
 ![AWS lambda screenshot](../../images/posts/2019/0015-aws_lambda_screenshot.png)
@@ -203,7 +203,7 @@ The policy config is:
     4. Click **add**
 4. Save lambda and then the API will be created
 
-## 3. Extending that lambda
+## Extending that lambda
 
 One way to give more functions to this lambda is to set times to start or stop certain systems. For example you could want to start a system at 7 am and then stop it at 19 pm on workdays. This could be useful for `development` systems.
 

--- a/src/content/blog/0016-pypi.mdx
+++ b/src/content/blog/0016-pypi.mdx
@@ -13,7 +13,7 @@ draft: false
 > [!danger]
 > **DISCLAIMER:** A lot has changed since I wrote this. Even though this still works, I suggest using `uv` instead. See <FancyLink linkText="Exploring Astral's Fast Python Tools: uv and ruff" url="https://villoro.com/blog/astral-tools-uv-and-ruff/" dark="true"/>. I'm keeping this here for reference.
 
-## 1. Create a python package
+## Create a python package
 
 To work with python you only need a `.py` file. However if you are creating a package you need to follow a concrete structure and include some needed files.
 
@@ -26,7 +26,7 @@ pip search package_name
 > [!info]
 > You can also look for it at <FancyLink linkText="Pypi" url="https://pypi.org/"/>.
 
-### 1.1. Structure your project
+### Structure your project
 
 You should have your project inside a folder with the name of the package. This will be the `root` of your project and should include `.gitignore`, `README.md` and `LICENSE.txt` among other configuration files.
 
@@ -45,7 +45,7 @@ The code should be inside another folder with the name of the package. So the st
     └── setup.py
 ```
 
-#### 1.1.1. Main files
+#### Main files
 
 All files inside `/package_name/package_name` should have imports that work from the main path. For example to import the `file1` in `file2` you should:
 
@@ -71,7 +71,7 @@ import package_name
 package_name.public_function() # This will call the 'public_function' from 'file2.py'
 ```
 
-#### 1.1.2. setup.py
+#### setup.py
 
 This is where you define the package itself, how can it be installed and some basic information about it. A basic example would be:
 
@@ -96,13 +96,13 @@ setup(
 )
 ```
 
-##### 1.1.2.1. long_description param
+##### long_description param
 `long_description` is extracted from the `README.md`
 
 > [!info]
 > You can use other formats for the README like `ost`
 
-##### 1.1.2.2. install_requires param
+##### install_requires param
 `install_requires` is a list of requirements. In the example I get it from `requirements.txt`.
 
 You could also write the requirements by hand with:
@@ -114,11 +114,11 @@ install_requires=["pandas>0.22", "flask"]
 > [!info]
 > You should avoid requirements with a fixed number version use `<` or `>` instead.
 
-##### 1.1.2.3. package_data param
+##### package_data param
 
 The `package_data` parameter allows you to include all files inside `/package_name/resources/` path even if they are not `.py` files. This will be useful if you want to include `html` templates or `yaml`/`json` with data. 
 
-### 1.2. Create the package
+### Create the package
 
 Before creating the package I suggest you add some rules in the `.gitignore`:
 
@@ -136,9 +136,9 @@ python setup.py sdist bdist_wheel
 
 Then you will have `build` with the content of the package and `dist` with `tar` and `wheels` of the package (what will be uploaded).
 
-## 2. Upload the package
+## Upload the package
 
-### 2.1. Requirements
+### Requirements
 
 When you run `pip install package` you are actually downloading it from <FancyLink linkText="Pypi" url="https://pypi.org/"/>.
 There is also <FancyLink linkText="Test Pypi" url="https://test.pypi.org/"/> for testing purposes.
@@ -153,7 +153,7 @@ To upload the packages I suggest you use `twine`. You can install it with:
 pip install twine
 ```
 
-### 2.2. Uploading a package to test.pypi
+### Uploading a package to test.pypi
 
 You can run the next command which will upload all packages created in the `dist` folder:
 
@@ -173,7 +173,7 @@ pip install --index-url https://test.pypi.org/simple/ package_name
 pip install --index-url https://test.pypi.org/simple/ package_name==X.X.X
 ```
 
-## 2.3. Uploading a package to pypi
+## Uploading a package to pypi
 
 In order to upload the package to `pypi` the process is very similar to the step before:
 

--- a/src/content/blog/0017-passwords_encryption.mdx
+++ b/src/content/blog/0017-passwords_encryption.mdx
@@ -10,18 +10,18 @@ tags: [Python, Security]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 While working at `AM Managers` project we encountered some difficulties. We were a team of around 8 people and it was common to have internship every some months. So we regularly needed to help new people to set up all the tools needed at that project.
 
 It was also common that we wanted to include new passwords when we started using new tools like new APIs or new DB. At the beginning we were creating env vars for each password but every time someone added a new password all the time were forced to include it as a new env var.
 
-## 1. Dictionary of passwords
+## Dictionary of passwords
 Then we decided to create a dictionary of encrypted passwords that we could track with git along with one master password as an env var.
 
 After starting to have some EC2 instances we discovered that it was easier for us to have a file with the master password than an env var.
 
-## 2. The v-crypt package
+## The v-crypt package
 After having the same problem with more projects I decided that it was better to create a new python package that could help me dealing with that instead of copying the code from the `AM Managers` repository all the time.
 
 The idea behind this module is to be able to **create a `json` or `yaml` with encrypted secrets**. The keys will be public but the values won't. This way you can **store the dictionary of secrets in git** and easily share them with other people working in the same project. You will only need to **share the `master.password` once**. And all the other passwords/secrets will be tracked with git.
@@ -30,7 +30,7 @@ It uses **Fernet** from the <FancyLink linkText="Cryptography" url="https://cryp
 
 ![Fernet encryption](../../images/posts/2019/0017-fernet_encryption.jpg)
 
-### 2.1 How it works
+### How it works
 It is really easy to use:
 
 ```python
@@ -49,7 +49,7 @@ cipher.save_secret("secret", "I like python")
 cipher.get_secret("secret")
 ```
 
-### 2.2. Customization
+### Customization
 
 There are three parameters to customize the cipher:
 
@@ -70,7 +70,7 @@ This will allow you to store both the `master.password` and `secrets.yaml` in th
 
 There is not much more customization since the idea is to keep it simple.
 
-### 2.3. How we use it
+### How we use it
 
 We usually have one or more python files with utilities, for example `utilities.py`.
 

--- a/src/content/blog/0018-logging.mdx
+++ b/src/content/blog/0018-logging.mdx
@@ -10,7 +10,7 @@ tags: [Python, Tools]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 > [!danger]
 > **Disclaimer:** A lot has changed since I wrote this. I no longer recommend following my steps.
@@ -18,7 +18,7 @@ draft: false
 
 In almost every program that we write we will need to show some output. The first thing that developers use is the `print` function but this lacks some really important features such as providing the time when the message was produced and the ability to save the output to a file. This is why it is better to use `logging`.
 
-## 1. pygogo
+## pygogo
 
 As always the first thing you should do when you need something is to look at the existing packages to avoid reinventing the wheel. <FancyLink linkText="Pygogo" url="https://github.com/reubano/pygogo" dark="true"/> is a nice python package that is easy to use.
 
@@ -36,11 +36,11 @@ What I believe it lacks:
 > [!note]
 > So I decided to create my own logging library
 
-## 2. v-log
+## v-log
 
 What I wanted was a `log` that would output good looking messages to the console while writing a properly formatted `csv` for further analysis. It is difficult to achieve that with the regular `logging` library so I created `v-log`.
 
-### 2.1. Using v-log
+### Using v-log
 
 To install it run:
 
@@ -81,13 +81,13 @@ This is what you will see with the above example:
 > [!info]
 > Output in the console will have colors. `debug` is green, info the default color, `warning` is orange and both `error` and `critical` are red.
 
-### 2.2. How it works
+### How it works
 
 `v-log` creates a `VLogger` class that is a wrapper that has 2 logs inside, one for the file output and another one for the terminal. This way if you call `log.info` it will call both `log_terminal.info` and `log_console.info` functions.
 
 The second interesting part is that you can pass `time` as an argument and it will process it. You can also pass an exception and it will show the **line** where the error happened, the **type** of error and the **details**.
 
-### 2.3. Customizating v-log
+### Customizating v-log
 
 When creating the `VLogger` instance you can define:
 

--- a/src/content/blog/0019-numba.mdx
+++ b/src/content/blog/0019-numba.mdx
@@ -12,12 +12,12 @@ draft: false
 
 <script type="module" src="/js/posts/0019-plots-numba.js"></script>
 
-## 0. Intro
+## Intro
 
 This is the first post about python performance.
 This post will be of how to make python code go faster.
 
-## 1. Exploring python compilers
+## Exploring python compilers
 The first way to improve the python performance is by using different compilers. The most famous ones are:
 
 <div class="flex justify-center">
@@ -28,7 +28,7 @@ The first way to improve the python performance is by using different compilers.
 
 **Numba** and **cython** are similar in terms of speed and **pypy** is a little bit slower. You can read more at <FancyLink linkText="How to use Cython, Numba and Pypy" url="https://www.quora.com/How-do-Cython-Numba-and-PyPy-compare-in-terms-of-performance-ease-of-use-and-restrictions"/>.
 
-### 1.1. Cython overview
+### Cython overview
 **Cython** is an optimising static compiler for both the Python programming language and the extended Cython programming language (based on Pyrex).
 
 When using cython you will need to specify variables classes so the code will look slightly different. For example:
@@ -69,7 +69,7 @@ setup(
 
 Even though cython is fast I don't like having to change the code to adapt it to cython.
 
-### 1.2. Pypy overview
+### Pypy overview
 
 **PyPy** is a fast, compliant alternative implementation of the Python language (2.7.13 and 3.5.3, 3.6). It has several advantages and distinct features:
 
@@ -80,7 +80,7 @@ Even though cython is fast I don't like having to change the code to adapt it to
 
 When using **pypy** you can write regular python code. The main disadvantage of pypy is that you can't use other libraries out of the box. So if for example you wan to use **pandas** you will need a **pypy** implementation of it. This makes using pypy along common python packages unconvinient. 
 
-### 1.3. Numba overview
+### Numba overview
 
 **Numba** translates Python functions to optimized machine code at runtime using the industry-standard LLVM compiler library. Numba-compiled numerical algorithms in Python can approach the speeds of C or FORTRAN.
 
@@ -88,7 +88,7 @@ You don't need to replace the Python interpreter, run a separate compilation ste
 
 So you can use python code without modifications and you won't have compatibility problems with other packages when using numba. This is the reason I prefer **numba** over **cython** and **pypy** and it is also one of the faster of the three.
 
-## 2. Using numba
+## Using numba
 
 **Numba** provides some decorators that will transform functions to `C`. This way the execution times will be faster.
 
@@ -111,7 +111,7 @@ m_sum([1, 2, 3])
   \> 6
 </TerminalOutput>
 
-### 2.1. `jit` vs `njit` decorators
+### `jit` vs `njit` decorators
 
 The default **numba** decorator is `jit`. It is possible to pass use nopython mode with `@jit(nopython=True)` or with the decorator `njit` which is equivalent.
 `njit` decorator is faster than `jit` but supports less features than jit.
@@ -119,7 +119,7 @@ The default **numba** decorator is `jit`. It is possible to pass use nopython mo
 For example you can't cast to string (with for example `str(10)`) inside a `njit` decorated function.
 So you should try to use `njit` decorator if possible specialy for numerical calculations.
 
-### 2.2. `vectorize` decorator
+### `vectorize` decorator
 
 Using the `vectorize` decorator, you write your function as operating over input scalars, rather than arrays. **Numba** will generate the surrounding loop (or kernel) allowing efficient iteration over the actual inputs.
 
@@ -160,9 +160,9 @@ square(mlist)
 
 The format for declaring the `dtypes` is `[output(input1, input2, ...)]`.
 
-## 3. Test numba performance
+## Test numba performance
 
-### 3.1. Test `sum` function
+### Test `sum` function
 
 First we will time the execution of different `sum` functions. The first option will be a for loop in python:
 
@@ -226,7 +226,7 @@ In all cases using the raw loop `iter_and_sum` or the default python `sum` gives
 > [!success]
 > **numba** can be **400x** better than a python loop
 
-### 3.2. Test fix time
+### Test fix time
 
 At one of the projects I was working at my company I found an interesting problem.
 I had a huge dataframe (650 milion rows) and among other columns there was one for the `date` and one for `time`.
@@ -240,13 +240,13 @@ The original format was `hhmmsscc` (`c` for centiseconds) and instead of being a
 |  9051137 | 09:05:11.37   |
 |      712 | 00:00:07.12   |
 
-#### 3.2.1. The functions
+#### The functions
 
 So to fix that I transformed the values to string, then added 0 until I had 8 chars and finally split and add `:` and `.` so that then it could be transformed.
 
 Let's use this problem for testing **numba**. First let's see all different options I came up.
 
-##### 3.2.1.1. zfill
+##### zfill
 
 This was my first approach which was good enough. The idea is to transform the `time` column to string and then apply `zfill(8)`. After that I created a string with the appropiate format and transform the whole `datetime` with `pd.to_datetime`.
 
@@ -263,7 +263,7 @@ def zfill(df):
     return pd.to_datetime(df["date"] + " " + aux[:2] + ":" + aux[2:4] + ":" + aux[4:6] + "." + aux[6:])
 ```
 
-##### 3.2.1.2. fix_time_individual
+##### fix_time_individual
 
 The idea in this option is to create a function decorated with `jit` that transform one element of the `time` column and apply the function to the column.
 
@@ -285,7 +285,7 @@ def fix_time_individual(df):
     return (df["date"] + " " + df["time"].apply(_fix_time)).astype(np.datetime64)
 ```
 
-##### 3.2.1.3. fix_time_np_string
+##### fix_time_np_string
 
 With this solution I created and empty `numpy` array and filled with a loop inside the `jit` decorated function.
 
@@ -314,7 +314,7 @@ def fix_time_np_string(df):
     return (df["date"].values + " " + _fix_time(df["time"].values)).astype(np.datetime64)
 ```
 
-##### 3.2.1.4. fix_time_np_datetime
+##### fix_time_np_datetime
 
 In this case the I also create an empty `numpy` array but with `datetime64[s]` dtype. This way I can iterate over both `time` and `date` at the same time.
 
@@ -346,7 +346,7 @@ def fix_time_np_datetime(df):
     return _fix_date(df["date"].values, df["time"].values)
 ```
 
-##### 3.2.1.5. np_divmod_jit
+##### np_divmod_jit
 
 In this solution I process the `time` column as number and with the `np.divmod` function I create a value that represents a **timedelta**. After transforming the `time` column I change the dtype to `timedelta64[ms]` and sum it to the `date` column as a `datetime64`.
 
@@ -376,7 +376,7 @@ def np_divmod_jit(df):
     return _fix_date(df["date"].values, df["time"].values)
 ```
 
-##### 3.2.1.6. divmod_njit
+##### divmod_njit
 
 It is the same as the previous example but after changing `np.divmod` to the python `divmod` function I can use the `njit` decorator for the first time.
 
@@ -408,7 +408,7 @@ def divmod_njit(df):
     ).astype("timedelta64[ms]")
 ```
 
-##### 3.2.1.7. divmod_vectorize
+##### divmod_vectorize
 
 This case is exactly the same as the previous one but instead of doing the `for` loop I use the **numba** `vectorize` decorator.
 
@@ -434,7 +434,7 @@ def divmod_vectorize(df):
     ).astype("timedelta64[ms]")
 ```
 
-#### 3.2.2. The results
+#### The results
 
 | size |    zfill | fix_time_individual | fix_time_np_string | fix_time_np_datetime | np_divmod_jit | divmod_njit | divmod_vectorize |
 |-----:|---------:|--------------------:|-------------------:|---------------------:|--------------:|------------:|-----------------:|
@@ -453,7 +453,7 @@ Both `divmod_njit` and `divmod_vectorize` performs really well compared to the o
 > [!success]
 > Working with numbers in numba is really fast.
 
-#### 3.2.3. Speed with different machines
+#### Speed with different machines
 
 I did this test with up to `10^7` elements with my computer. I was not able to increase the number of elements due to an **out of memory error** (not enough RAM).
 
@@ -484,7 +484,7 @@ If we take a look at the results we can see that they both perform similar.
 
 It is important to remember that **pandas only work with one core** so I am not using the full potential of the machines. **Having more RAM allows to work with more data** but it does not increase the speed. With the **numba** vectorize the azure machine performs better as the size increases.
 
-## 4. More info
+## More info
 
 You can read the <FancyLink linkText="Numba documentation" url="http://numba.pydata.org/numba-doc/latest/index.html" company="numba"/>.
 Some examples of **numba** form their web page at <FancyLink linkText="Numba examples" url="http://numba.pydata.org/numba-doc/0.21.0/user/examples.html" company="numba"/>.

--- a/src/content/blog/0020-gitflow.mdx
+++ b/src/content/blog/0020-gitflow.mdx
@@ -10,7 +10,7 @@ tags: [GIT, Best Practices]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 When you work with a team to develop some program/package/solution is it a **must** to have some kind of **version control system**.
 It is even a really good idea if you are working alone. One of the most common solutions is `git`.
@@ -21,7 +21,7 @@ It is not limited to control code you can also use it to control documentation o
 
 If you are using git from the command line you should check <FancyLink linkText="Git guide" url="http://rogerdudler.github.io/git-guide/" company="default" dark="true"/> out.
 
-## 1. Using 'git flows'
+## Using 'git flows'
 
 There are some famous 'git flows' in the industry such as:
 
@@ -38,7 +38,7 @@ In this post I am going to explain how it works.
 > And only switch to <FancyLink linkText="Gitflow" url="https://danielkummer.github.io/git-flow-cheatsheet/" company="default" dark="true"/> if you actually needed to have **2 long lived branches** (`develop` + `main`)
 
 
-## 2. Gitflow
+## Gitflow
 
 ![Gitflow overview](../../images/posts/2019/0022-gitflow_overview.png)
 
@@ -48,7 +48,7 @@ If you add code to this branch it must be deployed to production.
 The `develop` branch is where you test your code before adding it to `production`.
 This is the branch that will have a snapshot of the development server if you have one.
 
-### 2.1. Features
+### Features
 
 To add new functionalities you can create a `feature` branch.
 Those start from the `develop` branch since it has the latest stable code.
@@ -59,7 +59,7 @@ Once they are finished they get merged to the `develop` branch.
 > [!info]
 > **Feature** branches can have any name preceded by `feature/`
 
-### 2.2. Releases
+### Releases
 
 Once you want to add new things to production you can do a `release`.
 By defition they start from the `develop` branch.
@@ -72,7 +72,7 @@ After closing the release it will add a tag to the `master` branch with the vers
 > [!info]
 > To add the correct tag **release** branches should have the name of the new version you are creating preceded by `release/` like `release/x.x.x`
 
-### 2.3. Hotfixes
+### Hotfixes
 
 `Hotfixes` are created if and only if there is a thing in production that needs to be fixed before doing a release.
 This usually means that there is some blocking problem to fix. This is way they are created form the `master` branch.
@@ -80,7 +80,7 @@ When closing a `hotfix` it will be merged to both `master` and `develop`, like a
 
 ![Gitflow hotfix](../../images/posts/2019/0020-gitflow_hotfix.png)
 
-## 3. Using code revision
+## Using code revision
 
 Since you are probably working with a team it is a good idea to have code revision at some point.
 This way everybody can check other's people code and it will be easier to see if there are errors/problems.
@@ -100,7 +100,7 @@ If you want you can also create pull requests to close a `release` or a `hotfix`
 * after closing the pull request remember to also merge the `release`/`hotfix` into the `develop` branch.
 
 
-## 4. Using gitflow with some git programs
+## Using gitflow with some git programs
 
 If you use **git** from a terminal check this <FancyLink linkText="Gitflow guide" url="https://danielkummer.github.io/git-flow-cheatsheet/" company="default" dark="true"/> for using gitflow.
 
@@ -109,7 +109,7 @@ This will suggest you the next **gitflow** action.
 
 If you are using <FancyLink linkText="Sublime Merge" url="https://www.sublimemerge.com/"/> you can press `CTRL` + `P` to open the command box and type `gitflow` to performe the action you want.
 
-## 5. Conventions
+## Conventions
 
 When you are working with **gitflow** you are creating branches with some prefixes which can be customized.
 If you change them remember to specify it in the `README`. For example I usually use those prefixes since are shorter:
@@ -118,7 +118,7 @@ If you change them remember to specify it in the `README`. For example I usually
 * release: `r/`
 * hotfix: `h/`
 
-### 5.1. Version numbers
+### Version numbers
 
 As said before `releases` and `hotfixes` should be named with the new version you are deploying like for example 1.2.0.
 Version numbers are usually three numbers separated by `.` where they represent:

--- a/src/content/blog/0021-git_ssh.mdx
+++ b/src/content/blog/0021-git_ssh.mdx
@@ -10,13 +10,13 @@ tags: [GIT, Security, Setup]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 **Secure Shell (SSH)** is a cryptographic network protocol for operating network services securely over an unsecured network. This allows you to connect securely to other services or machines.
 
 In this post I am going to explain how to configure your linux machine to github using **SSH**.
 
-## 1. Create **SSH keys**
+## Create **SSH keys**
 
 First we will create a SSH key that will allow you to connect to github.
 
@@ -28,7 +28,7 @@ Then I suggest you save the SSH key with some useful name like `/home/ubuntu/.ss
 
 Finally add a passphrase. This will ensure that your SSH credentials are safe even if someone access your computer.
 
-## 2. Use keychain
+## Use keychain
 
 > [!info]
 > If you are using **Windows** you don't need to do that step.
@@ -63,7 +63,7 @@ eval `keychain --agents ssh --eval github_ssh`
 > [!info]
 > `github_ssh` is the name of the SSH key to import you could add more separating them by spaces
 
-## 3. Add the SSH key to github
+## Add the SSH key to github
 
 This guide focus on github but you can do the same following similar steps for other git services like bitbucket.
 
@@ -74,7 +74,7 @@ This guide focus on github but you can do the same following similar steps for o
 5. Use some meaningful name like `aws_ec2`, paste the SSH key and save it.
 6. If asked, write your github password.
 
-## 4. Check the SSH connection
+## Check the SSH connection
 
 The first thing you should do is to **restart** the terminal so that changes can be applied.
 
@@ -89,7 +89,7 @@ The first time it will say that the authenticity of **github.com** can't be esta
 > [!success]
 > You should see a message saying `Hi XXXX! You've successfully authenticated`
 
-## 5. Cloning a **git** repo
+## Cloning a **git** repo
 
 Since you are using **SSH** the clone command will change a little bit. Instead of using:
 

--- a/src/content/blog/0022-google_analytics_etl.mdx
+++ b/src/content/blog/0022-google_analytics_etl.mdx
@@ -11,14 +11,14 @@ tags: [API, Python, Pandas, DE, Tutorial]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 Google Analytics is really useful but sometimes you want to retrieve all the data and perform your own analysis and create your reports.
 In this post you will see how to do that with python.
 
-## 1. Google permisions and keys
+## Google permisions and keys
 
-### 1.1. Get the Google key
+### Get the Google key
 
 The first thing to do is to download the Google key. To do so you only need to follow <FancyLink linkText="Google Analytics API" url="https://developers.google.com/analytics/devguides/reporting/core/v3/quickstart/service-py"/> steps.
 
@@ -31,7 +31,7 @@ To sum them up you will need to:
 5. Create a `json` private key
 6. Download that key. It will allow you to access google data
 
-### 1.2. Enable Google Analytics API
+### Enable Google Analytics API
 
 You will need to enable the usage of the Google Analytics API with:
 
@@ -39,7 +39,7 @@ You will need to enable the usage of the Google Analytics API with:
 2. Make sure to select the desired project from the navigation bar (at the top).
 3. Click enable
 
-### 1.3. Allow the user to see Google Analytics data
+### Allow the user to see Google Analytics data
 
 From the previous step you created and account with an email similar to `your_project@your_web.iam.gserviceaccount.com`
 (you obviously need to change `your_web` and `your_project`). Then give it read permissions with:
@@ -53,13 +53,13 @@ From the previous step you created and account with an email similar to `your_pr
 > [!warning]
 > It can take some time until the new user has reading permissions.
 
-### 1.4. Profile ID
+### Profile ID
 
 Get the ID that you will need to use with the API. There are three levels and the ID that you need to use is in the last one, the one with the red mark in the image.
 
 ![Google Analytics Profile](../../images/posts/2019/0022-google_analytics_profile.jpg)
 
-## 2. Test the conection
+## Test the conection
 
 You can run the `test_connection.py` code to check that everything is working.
 
@@ -117,8 +117,8 @@ def test():
 > [!warning]
 > Remember to edit both `FILE_GA_KEY` and `PROFILE` constants using the values from the previous steps.
 
-## 3. Building the ETL
-### 3.1. Decide metrics and dimensions
+## Building the ETL
+### Decide metrics and dimensions
 
 Now is the time to decide what you want to download. There are two types of parameters **metrics** and **dimensions**.
 
@@ -128,7 +128,7 @@ Now is the time to decide what you want to download. There are two types of para
 You can check with <FancyLink linkText="Query explorer" url="https://ga-dev-tools.appspot.com/query-explorer/" company="google"/> the possible values for both
 of them and you can also try your queries.
 
-### 3.2. Extract and transform the data
+### Extract and transform the data
 
 In this step I will describe functions in the `etl.py` file.
 
@@ -291,24 +291,24 @@ def import_old_stats(end=date.today()):
 
 Right now it will download all data from 2017 until today.
 
-### 3.3. Load the data
+### Load the data
 
 In this example I'm going to show how to insert the data into **MySQL**.
 All this code is from `sql.py` file.
 
-#### 3.3.1. Handling duplicated data
+#### Handling duplicated data
 
 The idea is that the ETL can be run more than once without creating duplicated data.
 This is also important since the ETL is designed with redundancy to allow some failures so it is needed to handle duplicates.
 
 There are two approaches to this problem:
 
-##### 3.3.1.1. Using date as identifier
+##### Using date as identifier
 
 Every time you download data you will have a dataframe with info of the last 7 days.
 In order to avoid duplicates you can simply delete all rows that have data within the same days.
 
-##### 3.3.1.2. Use all 'index' columns
+##### Use all 'index' columns
 
 The other approach is to load all existing data and concatenate with the new one.
 This dataframe will have duplicates but they can be deleted with the `drop_duplicates` **pandas** function.
@@ -316,7 +316,7 @@ To do so you need to specify which are the columns that define a unique entry.
 
 This solution is less efficient since it will need to load all existing data and this can be time consuming.
 
-#### 3.3.2. Load code
+#### Load code
 
 The first thing to do is to create the SQL Alchemy engine for MySQL.
 For other SQL engines check the <FancyLink linkText="SQL Alchemy with python" url="https://villoro.com/blog/sql-alchemy-python/" dark="true"/>.

--- a/src/content/blog/0023-dropbox_python.mdx
+++ b/src/content/blog/0023-dropbox_python.mdx
@@ -10,13 +10,13 @@ tags: [Python, Pandas, DE]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 When developing with python people usually want to store some data.
 If this data is quite big and/or contains personal information it is not advised to store it in **github** (or other git providers).
 One good option is to store it in <FancyLink linkText="Dropbox" url="https://www.dropbox.com/"/>.
 
-## 1. Using dropbox with python
+## Using dropbox with python
 Dropbox has a really nice package that you can install with
 
 ```sh
@@ -38,7 +38,7 @@ Once you have create the app go to the app settings page and create a token.
 
 You can now store that secret in a safe way (for example as an environment variable or a hidden file).
 
-## 2. Working with BytesIO
+## Working with BytesIO
 
 The key to write or read files is using `io.BytesIO` object.
 
@@ -69,7 +69,7 @@ with io.BytesIO(txt.encode()) as stream:
 > [!warning]
 > It is important to run `stream.seek(0)` to go to the beginning of the stream.
 
-## 3. Writting files to dropbox
+## Writting files to dropbox
 
 The first thing you need to do is to init the dropbox object with:
 
@@ -82,7 +82,7 @@ DBX = dropbox.Dropbox(token)
 
 After creating the `DBX` instance you can upload files using `DBX.files_upload`.
 
-### 3.1. Write a text file
+### Write a text file
 
 You will need to create the `io.BytesIO` object and upload it.
 
@@ -101,7 +101,7 @@ To allow overwriting you need to pass `mode=dropbox.files.WriteMode.overwrite` t
 > [!warning]
 > **Important:** filenames should start with `/`. It won't work without it.
 
-### 3.2. Write a json
+### Write a json
 
 To write a dictionary-like file you can use the following:
 
@@ -118,7 +118,7 @@ with io.StringIO() as stream:
     DBX.files_upload(stream.read().encode(), "/test.json", mode=dropbox.files.WriteMode.overwrite)
 ```
 
-### 3.3. Write a yaml
+### Write a yaml
 
 It is very similar to writing a `json`:
 
@@ -138,7 +138,7 @@ with io.StringIO() as stream:
 
 This time we are encoding the stream to transform it to bytes.
 
-### 3.4. Write an Excel with Pandas
+### Write an Excel with Pandas
 
 ```python
 import pandas as pd
@@ -158,7 +158,7 @@ with io.BytesIO() as stream:
 
 The key is to use the `ExcelWriter` from **pandas**.
 
-### 3.5. Write a csv with Pandas
+### Write a csv with Pandas
 
 Unfortunatelly it is not possible to dump a `csv` directly with **Pandas** into a `StringIO` at this time (More info: <FancyLink linkText="Pandas issue 22555" url="https://github.com/pandas-dev/pandas/issues/22555" dark="true"/>)
 
@@ -175,12 +175,12 @@ with io.BytesIO(data.encode()) as stream:
     DBX.files_upload(stream.read(), "/test.csv", mode=dropbox.files.WriteMode.overwrite)
 ```
 
-## 4. Reading files
+## Reading files
 
 To read a file you can use `DBX.files_download`.
 This will return some metadata as the first parameter and the result of the **API** call as the second.
 
-### 4.1. Read a text file
+### Read a text file
 
 ```python
 _, res = DBX.files_download("/test.txt")
@@ -194,7 +194,7 @@ with io.BytesIO(res.content) as stream:
 > [!warning]
 > Remember to decode the stream to transform it from bytes to string
 
-### 4.2. Read a json
+### Read a json
 
 ```python
 _, res = DBX.files_download("/test.json")
@@ -203,7 +203,7 @@ with io.BytesIO(res.content) as stream:
     data = json.load(stream)
 ```
 
-### 4.3. Read a yaml
+### Read a yaml
 
 ```python
 _, res = DBX.files_download("/test.yaml")
@@ -215,7 +215,7 @@ with io.BytesIO(res.content) as stream:
 > [!warning]
 > You should always use `yaml.safe_load` instead of `yaml.load`
 
-### 4.4. Read an Excel with Pandas
+### Read an Excel with Pandas
 
 ```python
 _, res = DBX.files_download("/test.xlsx")
@@ -227,7 +227,7 @@ with io.BytesIO(res.content) as stream:
 > [!tip]
 > If you do not want a new dummy index use `index_col=0`.
 
-### 4.5. Read a csv with Pandas
+### Read a csv with Pandas
 
 ```python
 _, res = DBX.files_download("/test.csv")
@@ -236,11 +236,11 @@ with io.BytesIO(res.content) as stream:
     df = pd.read_csv(stream, index_col=0)
 ```
 
-## 5. Deleting files
+## Deleting files
 
 To delete a file simply call `DBX.files_delete(filename)`.
 
-## 6. Working with other formats
+## Working with other formats
 
 With this post you should have enough to work with **dropbox** using python.
 However, if you need to work another format look on how to create a `StringIO` object that represent this format.

--- a/src/content/blog/0024-pandas_intro.mdx
+++ b/src/content/blog/0024-pandas_intro.mdx
@@ -10,7 +10,7 @@ tags: [Python, Pandas, Intro]
 draft: false
 ---
 
-## 0. Overview
+## Overview
 
 **Pandas** is a python library used for working with tabular data.
 It is easy to use and it is fast since it uses **C** under the hood.
@@ -37,9 +37,9 @@ print(pd.__version__)
 > [!note]
 > This tutorial uses pandas **0.25.3** since it was the latest version available at the time this post was written.
 
-## 1. Input/Output operations (reading and writing data).
+## Input/Output operations (reading and writing data).
 
-### 1.1. pd.DataFrame
+### pd.DataFrame
 To create a new DataFrame from python objects use `pd.DataFrame`.
 It works with almost all python objects, for example:
 
@@ -47,7 +47,7 @@ It works with almost all python objects, for example:
 df = pd.DataFrame({"A": range(5), "B": list("ABCDE")})
 ```
 
-### 1.2. Read
+### Read
 The most common reading function is `pd.read_csv`.
 But there are also functions to read almost everything (<FancyLink linkText="Pandas docs" url="https://pandas.pydata.org/pandas-docs/stable/reference/io.html" company="pandas" dark="true"/>).
 
@@ -59,7 +59,7 @@ df = pd.read_csv("datasets/titanic_train.csv")
 df_iris = pd.read_excel("datasets/iris.xlsx")
 ```
 
-### 1.3. Write
+### Write
 Dataframes have functions that allows you to export them to almost any format.
 For example you can export it to `parquet` (a really efficient file format, more info <FancyLink linkText="Storing tables efficiently with Pandas" url="https://villoro.com/blog/storing-tables-efficiently-pandas/" dark="true"/>).
 
@@ -67,12 +67,12 @@ For example you can export it to `parquet` (a really efficient file format, more
 df.to_parquet("datasets/output.parquet")
 ```
 
-## 2. Overview data
+## Overview data
 
 **Pandas** is usually used to handle a lot of data so it is difficult to view all of it.
 That is why is important to preview, describe and summarize the data it contains.
 
-###  2.1. Preview data
+###  Preview data
 
 One of the most basic things to do is to view a part of the data.
 The three most common functions to do so are:
@@ -83,7 +83,7 @@ The three most common functions to do so are:
 | `df.tail(n)`   | Show last n rows        |
 | `df.sample(n)` | Show a sample of n rows |
 
-### 2.2. Describe the dataframe
+### Describe the dataframe
 
 There are some ways to describe the whole dataframe.
 The most common way is by calling `df.describe()`.
@@ -103,7 +103,7 @@ df.info(memory_usage='deep')
 
 This will show the types of each column and an approximation of how much memory is used.
 
-### 2.3. View a column (Series)
+### View a column (Series)
 
 A column of the dataframe in pandas is called a **Series**.
 To best way to view a column is with `df[name]`.
@@ -120,7 +120,7 @@ There are also some functions to describe the column. The most important are:
 | `df[column].unique()`       | Show all unique values                                           |
 | `df["Sex"].value_counts()`  | Show all unique values while counting how many times they appear |
 
-### 2.4. Summarize
+### Summarize
 
 There are some functions to retrieve one basic stat for the whole dataframe. Those are:
 
@@ -137,12 +137,12 @@ As an example they can be called with `df.mean()`.
 
 They can also be used for a column like `df[col].nunique()`.
 
-## 3. Slicing
+## Slicing
 
 **Pandas** is usually used to work with a lot of information.
 So it is really important to know how to slice the dataframe to get a subset of it.
 
-### 3.1. Get one value
+### Get one value
 
 The best way to get one value is with the `.at` method.
 The first parameter would be the name of the row and the second the name of the column.
@@ -154,7 +154,7 @@ df.at[1, "Sex"]
 
 This would yield the value of the `Sex` column on the row with index `1`.
 
-### 3.2. Accessing one or more columns
+### Accessing one or more columns
 
 As seen in the previous section a column can be called like `df["Sex"]`.
 By passing a list instead of only one name it will return some columns.
@@ -164,7 +164,7 @@ For example:
 df[["Sex", "Age"]] # Return 'Age' and 'Sex' columns
 ```
 
-### 3.3. Filter rows
+### Filter rows
 
 To filter some rows you will need to call `df[some_filter]`.
 This filter could be complex by using the and operator (`&`), the or (`|`) or the not (`~`).
@@ -194,7 +194,7 @@ df[df["Pclass"].isin([1, 2])] # All with 'Pclass' 1 or 2
 df[df["Cabin"].isna()] # All that does not have 'Cabin' informed
 ```
 
-### 3.4. Filtering rows and columns at the same time
+### Filtering rows and columns at the same time
 
 You can use `loc` when using rows/columns names or `iloc` when using the position (number) for rows/columns.
 Some examples:
@@ -213,11 +213,11 @@ So you must really get comfortable with it!
 > [!warning]
 > You might find the function `ix` but it has been deprecated in favor of `loc/iloc`. Please do not use `ix`.
 
-## 4. Modify data
+## Modify data
 
 It is important to see the data but it is usually not enough.
 
-### 4.1. Basic modifications
+### Basic modifications
 In general you can assign values by using the same functions that were used to access data.
 For example:
 
@@ -229,8 +229,8 @@ df["Ticket"] = "no ticket" # Assign a value to all rows
 df["Dummy"] = df["Age"] + df["Survived"] # sum to columns and assign the value to a new column
 ```
 
-### 4.2. Special types
-#### 4.2.1. Strings
+### Special types
+#### Strings
 
 For columns that have string values it is possible the call `.str` and use some string special functions.
 As an example:
@@ -243,7 +243,7 @@ df["Name"] = df["Name"].str.replace("Mr", "Hello") # This updates the values
 df["Name"].str[:10] # First 10 chars of each string
 ```
 
-#### 4.2.2. Datetime
+#### Datetime
 
 There are also some special functions for date columns by calling `.dt`.
 But to use them first you would need to transform the column to datetime.
@@ -263,7 +263,7 @@ df["key"].dt.day # Gets the day
 df["key"].dt.strftime("%Y-%m-01") # Get first day of the month
 ```
 
-### 4.3. Missing values
+### Missing values
 
 The function `fillna` will fill the missing values.
 In order to update the original values you need to set **inplace** to true (`fillna.(fill_value, inplace=True)`)
@@ -275,7 +275,7 @@ df["Cabin"].fillna("Unknown")
 
 It is also possible to drop rows with missing values with `df[col].dropna()`
 
-### 4.4. Sorting
+### Sorting
 
 This is really straight forward:
 
@@ -283,7 +283,7 @@ This is really straight forward:
 df.sort_values("Cabin", ascending=False) # Default ascending=True
 ```
 
-### 4.5. Handling duplicates
+### Handling duplicates
 
 It is possible to drop rows that have duplicates with:
 
@@ -291,7 +291,7 @@ It is possible to drop rows that have duplicates with:
 df.drop_duplicates(["Pclass"]) # Discard the duplicates based on certain columns
 ```
 
-### 4.6. Custom functions
+### Custom functions
 You can apply custom functions.
 Remember that usually functions have names but you can define unnamed functions using lambdas.
 As an example:
@@ -328,7 +328,7 @@ def custom_categories(x):
 df["SL"].apply(custom_categories)
 ```
 
-### 4.7. Apply changes to a slice
+### Apply changes to a slice
 It is possible to apply changes to only part of the dataframe using `loc`.
 For example:
 
@@ -345,9 +345,9 @@ df.loc[mfilter, "Age"] = df.loc[mfilter, "Age"]*2
 
 This will double the Age for all rows where `Embarked = S`.
 
-## 5. Modify the dataframe
+## Modify the dataframe
 
-### 5.1. Delete rows/columns
+### Delete rows/columns
 
 This is done with `df.drop`. To delete rows set `axis=0` and `axis=1` for columns.
 For example:
@@ -357,7 +357,7 @@ df.drop("Dummy", axis=1)
 df.drop(["Dummy", "Fare", "Cabin"], axis=1, inplace=True) # inplace=True to update the original dataframe
 ```
 
-### 5.2. Rename columns
+### Rename columns
 
 The function `df.columns` retrieves the names of the columns.
 To rename them simply pass a list with the desired names. For example:
@@ -366,8 +366,8 @@ To rename them simply pass a list with the desired names. For example:
 df.columns = ['id', 'survived', 'pclass', 'name', 'sex', 'age', 'sibsp', 'parch', 'ticket', 'embarked']
 ```
 
-## 6. Transformations
-### 6.1. Group by values
+## Transformations
+### Group by values
 
 A really common transformation for tables is to group them by one or more columns.
 Once the aggrupation is done you can call one or more aggregation function.

--- a/src/content/blog/0025-pyspark_intro.mdx
+++ b/src/content/blog/0025-pyspark_intro.mdx
@@ -11,7 +11,7 @@ tags: [Python, Spark, Intro]
 draft: false
 ---
 
-## 0. Overview
+## Overview
 
 Apache Spark is a very fast unified analytics engine for big data and machine learning.
 It relies on <FancyLink linkText="MapReduce" url="https://www.ibm.com/analytics/hadoop/mapreduce"/> to split tasks and distribute them into a cluster.
@@ -31,9 +31,9 @@ This post is an introduction to **Spark DataFrames**.
 
 The installation of **spark** is no easy task and is out of the scope of this post.
 
-## 1. Create dataframe
+## Create dataframe
 
-### 1.1. Read file
+### Read file
 
 One of the most common ways to create a dataframe is by reading a file. 
 For example to read a `csv` you should:
@@ -51,7 +51,7 @@ It is even possible to use wildcards to read multiple files at once.
 sdf = spark.read.format("csv").load("titanic_*.csv") # Read both train and test
 ```
 
-### 1.2. RDD
+### RDD
 
 It is possible to read raw files with spark and process them.
 As an example we are reading a csv and transform it to a dataframe.
@@ -72,13 +72,13 @@ sdf = spark.createDataFrame(iris_data)
 > [!tip]
 > This is only an example; it is better to read it directly as a dataframe
 
-## 2. Inspect
+## Inspect
 
-### 2.1. Show data
+### Show data
 
 To show the data simply call `sdf.show(N)` where `N` is the number of rows (default=20)
 
-### 2.2. General info
+### General info
 
 There are some functions to get general info about the dataframe.
 
@@ -90,12 +90,12 @@ There are some functions to get general info about the dataframe.
 | `sdf.dtypes`     | Columns of the dataframe with their data types (dtypes) |
 | `sdf.describe()` | Basic stats of the dataframe                            |
 
-## 3. Slicing
-### 3.1. First rows
+## Slicing
+### First rows
 
 To retrieve the first N rows you can either use `sdf.head(N)` or `sdf.take(N)`.
 
-### 3.2. Filter columns
+### Filter columns
 
 To get one or more columns use `sdf.select`. For example:
 
@@ -104,7 +104,7 @@ sdf.select("Sex")
 sdf.select("Sex", "Age")
 ```
 
-### 3.3. Filter rows
+### Filter rows
 
 Filters in **pyspark** follow the same syntax as **pandas**.
 There are some synonyms for filtering. These 3 lines do exactly the same:
@@ -132,7 +132,7 @@ sdf[sdf["Name"].startswith("Hei")]
 sdf[sdf["Name"].endswith(".")]
 ```
 
-### 3.4. Unique values
+### Unique values
 
 ```python
 sdf.select("Pclass").distinct()
@@ -144,7 +144,7 @@ It is also possible to subtract values based on another list.
 sdf.select("Pclass").exceptAll(sdf.select("Survived"))
 ```
 
-## 4. Modify the dataframe
+## Modify the dataframe
 
 To modify a dataframe you need to update the original dataframe.
 For example you would do `sdf = do_something(sdf)`.
@@ -152,7 +152,7 @@ For example you would do `sdf = do_something(sdf)`.
 > [!warning]
 > It is possible to only call `do_something(sdf)` but **it won't update the dataframe**.
 
-### 4.1. Add columns
+### Add columns
 
 As an example, to add a column called `new_col` with the same value as `Age` do:
 
@@ -160,7 +160,7 @@ As an example, to add a column called `new_col` with the same value as `Age` do:
 sdf = sdf.withColumn("new_col", sdf["Age"])
 ```
 
-### 4.2. Change dtypes
+### Change dtypes
 
 **Dtypes** are changed using the `cast` method of a column.
 
@@ -172,7 +172,7 @@ sdf = sdf.withColumn("Age", sdf["Age"].cast(T.IntegerType()))
 > [!info]
 > You need to specify a type from `pyspark.sql.types`.
 
-### 4.3. Modify certain values
+### Modify certain values
 
 To modify the data itself use `sdf.withColumn`.
 You can either create a new column at the same time or update the existing one.
@@ -198,25 +198,25 @@ And replace values on certain columns:
 sdf.replace("male", "m", "Sex")
 ```
 
-### 4.4. Sort
+### Sort
 
 ```python
 sdf.sort("Age", ascending=False)
 ```
 
-### 4.5. Delete columns
+### Delete columns
 
 ```python
 sdf.drop("new_col")
 ```
 
-### 4.6. Drop duplicates
+### Drop duplicates
 
 ```python
 sdf.drop_duplicates(["Pclass"])
 ```
 
-### 4.7. User Defined Functions (UDF)
+### User Defined Functions (UDF)
 
 It is possible to define new functions and apply them to a column.
 To define it you need to specify the output type (int, str...).
@@ -234,7 +234,7 @@ def sum_1(x):
 sdf.withColumn("Next_Age", sum_1(sdf["Age"]))
 ```
 
-## 5. Group data
+## Group data
 
 To group data you can use the `sdf.groupby` method.
 It is possible to call simple functions like `count` or use `agg` to apply custom aggregations at once.
@@ -245,7 +245,7 @@ sdf.groupby("Sex").count()
 sdf.groupby("Sex").agg({"sex": "count", "Age": "max"})
 ```
 
-## 6. SQL
+## SQL
 
 One really useful feature of spark is that you can use **SQL** syntax and **spark** will translate and apply it.
 
@@ -264,7 +264,7 @@ spark.sql("SELECT * FROM titanic WHERE sex = 'female' LIMIT 5")
 > [!info]
 > The output of `spark.sql` is another dataframe and you can save it with `sdf = spark.sql`
 
-## 7. Write
+## Write
 
 **Spark** can write files in a lot of different formats. One of the best is `parquet`.
 To save a parquet file use:
@@ -273,7 +273,7 @@ To save a parquet file use:
 sdf.write.format("parquet").mode("overwrite").save("titanic_train.parquet")
 ```
 
-## 8. Interacting with python
+## Interacting with python
 
 Some times you need to retrieve some data from spark to python.
 

--- a/src/content/blog/0026-h2o_automl.mdx
+++ b/src/content/blog/0026-h2o_automl.mdx
@@ -14,7 +14,7 @@ draft: false
 
 <script type="module" src="/js/posts/0026-plots-h2o.js"></script>
 
-## 1. What is H2O
+## What is H2O
 
 According to their website, H2O is a fully open source, distributed in-memory machine learning platform with linear scalability.
 H2O supports the most widely used statistical & machine learning algorithms including gradient boosted machines, generalized linear models, deep learning and more.
@@ -23,7 +23,7 @@ It uses MapReduce to break down tasks so that it can send tasks to workers on a 
 
 H2O also has an AutoML functionality that automatically runs through all the algorithms and their hyperparameters to produce a leaderboard of the best models.
 
-## 2. H2O AutoML
+## H2O AutoML
 
 The best way to understand **AutoML** is by showing a practical case.
 As an example we will use the <FancyLink linkText="Higgs Challenge" url="https://www.kaggle.com/c/higgs-boson/data"/> data.
@@ -34,7 +34,7 @@ Since the preprocessing is out of the scope of this post we can directly use a c
   <Button label="Test data" link="https://s3.amazonaws.com/erin-data/higgs/higgs_test_5k.csv" style="solid" />
 </div>
 
-### 2.1. Start H2O session
+### Start H2O session
 
 This is really straightforward:
 
@@ -47,7 +47,7 @@ h2o.init()
 
 This code will init an H2O session.
 
-### 2.2. Get data
+### Get data
 
 The first step is to load the data.
 Then we will create a list with the names of all feature columns and another for the target.
@@ -72,7 +72,7 @@ test[y] = test[y].asfactor()
 > [!tip]
 > This creates an `H2O` dataframe. You can always transform it to **Pandas** with `x.as_data_frame()`
 
-### 2.3. Train
+### Train
 
 The first step is to create the `H2OAutoML` object.
 Since we aim to get reproducibility of the example we will set a seed.
@@ -90,7 +90,7 @@ Once the **AutoML** object is declared to train you only need to pass the `train
 aml.train(x=x, y=y, training_frame=train)
 ```
 
-### 2.3. Check results
+### Check results
 
 You can see the results with `lb = aml.leaderboard`.
 However it is more useful to see all possible information with:
@@ -118,7 +118,7 @@ The total training time (for all models) of the example was **limited to 2 minut
 | DRF_1_AutoML                        | 0.7652 | 0.5802  | 0.7833 | 0.3405               |
 | XRT_1_AutoML                        | 0.7651 | 0.5822  | 0.7831 | 0.3492               |
 
-## 3. H2O vs Manual ML
+## H2O vs Manual ML
 
 In order to compare the results of **H2O AutoML** I trained a Support Vector Classifier (SVC) and a Random Forest Classifier (RFC).
 Then I also did a GridSearchCV with the RandomForest to get some numbers.
@@ -145,7 +145,7 @@ Here you can see how all models perform:
 
 The training time with **AutoML** was lower than sklearn while having equal or better results.
 
-## 4. Sparkling water
+## Sparkling water
 
 Even though **H2O** uses MapReduce it might be useful to integrate it with spark.
 To do so you only need to use **Sparkling water**.

--- a/src/content/blog/0027-databricks.mdx
+++ b/src/content/blog/0027-databricks.mdx
@@ -12,7 +12,7 @@ tags: [Tools, Spark]
 draft: false
 ---
 
-## 0. Overview
+## Overview
 
 **Databricks** provides a Unified Analytics Platform that accelerates innovation by unifying data science, engineering and business.
 
@@ -25,20 +25,20 @@ There are two options:
 > [!tip]
 > I suggest you start trying it with the **Community Edition**
 
-## 1. Clusters
+## Clusters
 
-### 1.1. Cluster creation
+### Cluster creation
 
 In order to use databricks you will first need to create a cluster.
 The available options will change based on the **Databricks** version you are using.
 
-#### 1.1.1. Community Edition Version
+#### Community Edition Version
 
 With this version you can configure more things.
 
 ![Databricks Cluster Creation](../../images/posts/2019/0027-databricks_cluster_creation.png)
 
-##### 1.1.1.1. Cluster mode
+##### Cluster mode
 
 The default mode is `standard` and will work well for 1 user.
 For multiuser use `high concurrency`.
@@ -46,30 +46,30 @@ For multiuser use `high concurrency`.
 > [!warning]
 > If you want to use scala you must use `standard` cluster mode
 
-##### 1.1.1.2. Databricks runtime version
+##### Databricks runtime version
 
 Databricks runtimes are the set of core components that run on Databricks clusters.
 This will decide the `python`, `R` and `spark` version as well as some pre-installed libraries.
 
 You can read more about the versions of each databricks runtime in <FancyLink linkText="Databricks releases notes" url="https://docs.databricks.com/release-notes/runtime/supported.html#release-notes"/>.
 
-##### 1.1.1.3. Python version
+##### Python version
 
 **Use python 3**. Python 2 is deprecated so please do not use it.
 
-##### 1.1.1.4. Autopilot
+##### Autopilot
 
 The first parameter is `Enable Autoscaling`.
 This will allow to create more workers for the cluster if needed and of course it will mean that the cost might increase as you need more machines.
 
 There is the `terminate after` param that sets the minutes of inactivity before shutting down the cluster.
 
-##### 1.1.1.5. Environ vars
+##### Environ vars
 
 By clicking `Advanced Options` and then `Spark` you can set the **Environment Variables**.
 This is really useful to do some configuration at the cluster level.
 
-#### 1.1.2. Community Edition Version
+#### Community Edition Version
 
 If you are using the **Community Edition** version of databricks is really easy to create a new version.
 
@@ -77,7 +77,7 @@ You only need to write a cluster name and decide the databricks runtime version.
 
 ![Databricks Cluster Creation CE](../../images/posts/2019/0027-databricks_cluster_creation_community_edition.png)
 
-### 1.2. Permissions
+### Permissions
 
 In `Advanced Options` / `Permissions` is where permissions are set.
 The available options are:
@@ -86,7 +86,7 @@ The available options are:
 * **Can Restart:** allows to start, restart and close the cluster
 * **Can Manage :** admin privilege
 
-### 1.3. Libraries
+### Libraries
 
 There are multiple ways of installing python libraries:
 
@@ -113,7 +113,7 @@ You can see an example of the libraries installed on a cluster:
 And lastly you should avoid installing libraries using `dbutils`.
 This also won't work if you are using a `conda` databricks runtime.
 
-### 1.4. Logs
+### Logs
 
 There are some kind of logs:
 
@@ -128,26 +128,26 @@ There are some kind of logs:
 
 ![Databricks logs](../../images/posts/2019/0027-databricks_logs.jpg)
 
-#### 1.4.1. Event logs
+#### Event logs
 
 In this section is possible to view the actions performed to the cluster.
 For example a start of the cluster will be registered here.
 
-#### 1.4.2. Driver logs
+#### Driver logs
 
 Those are the logs that the **driver** machine writes.
 
 The `standard output` and `standard error` are self explanatory.
 The `log4j output` is the output that **spark** uses.
 
-#### 1.4.3. Spark logs
+#### Spark logs
 
 This allows to access the `stdout` and `stderr` logs of each spark worker.
 
 ![Databricks logs spark 1](../../images/posts/2019/0027-databricks_logs_spark_1.jpg)
 ![Databricks logs spark 2](../../images/posts/2019/0027-databricks_logs_spark_2.jpg)
 
-## 2. Notebooks
+## Notebooks
 
 The way to work with databricks is by using notebooks.
 They are really similiar to the <FancyLink linkText="Jupyter" url="https://jupyter.org/"/> notebooks so it should be easy if you already know them.
@@ -160,7 +160,7 @@ Once you create a new notebook you will need to set:
 
 You can later rename the notebook or attach it to another cluster if needed.
 
-### 2.1. Multilanguage
+### Multilanguage
 
 You can work with multiple languages in the same notebook even though there is a default one.
 To do so you only need to use some magic commands like `%python` to work with python.
@@ -179,13 +179,13 @@ The languages you can use are:
 | R              | %r      |
 | scala          | %scala  |
 
-### 2.2. Spark
+### Spark
 
 One of the great things about **databricks** is that it comes with spark install, configured and already imported.
 To use spark you can simply call `spark`.
 For example you could run in python `spark.sql("SELECT * FROM my_table")`.
 
-### 2.3. dbutils
+### dbutils
 
 **Databricks** comes with a class that has some utilities.
 This have 3 main functionalities:
@@ -195,22 +195,22 @@ This have 3 main functionalities:
 * Widgets (`dbutils.widgets`)
 * Package installer (`dbutils.library`)
 
-#### 2.3.1. dbutils.secrets
+#### dbutils.secrets
 
 This allows to interact with secrets.
 In Azure you will connect it to a Key Vault so that you can retrieve secrets from there.
 
-#### 2.3.2. dbutils.fs
+#### dbutils.fs
 
 This allows to write and read files.
 It is also used to mount external storage units such as a datalake or a blob.
 
-#### 2.3.3. dbutils.widgets
+#### dbutils.widgets
 
 You can create custom widgets that allow you to interact with the notebook.
 For example you can create and dropdown that sets the value of one python variable.
 
-#### 2.3.4. dbutils.library
+#### dbutils.library
 
 This allow you to install packages.
 I would advise to manage libraries with the `Libraries` section of the cluster configuration.
@@ -218,7 +218,7 @@ I would advise to manage libraries with the `Libraries` section of the cluster c
 > [!warning]
 > If you are using a **conda** environment `dbutils.library` won't work.
 
-### 2.4. display and displayHTML
+### display and displayHTML
 
 The `display` object is mainly used to show tables.
 You can pass a **spark** or **pandas** dataframe and it will be nicely displayed.
@@ -227,7 +227,7 @@ It also allows to create plots based on the dataframe.
 `displayHTML` as the name suggest allows to display HTML content.
 It is the equivalent of an `iframe` in HTML.
 
-## 3. Storing and reading data
+## Storing and reading data
 
 Databricks come with a folder where you can store data.
 It is under the path `/dbfs/FileStore`.
@@ -244,7 +244,7 @@ To read that in different languages you should:
 | spark    | dbfs:/mnt/blob/data.delta                    |
 | SQL      | SELECT * FROM delta.\`/mnt/blob/data.delta\` |
 
-## 4. Scheduling jobs
+## Scheduling jobs
 
 You can schedule jobs with the section `Jobs`.
 It works like the Linux **cron**.

--- a/src/content/blog/0028-pyspark_example.mdx
+++ b/src/content/blog/0028-pyspark_example.mdx
@@ -15,13 +15,13 @@ draft: false
 
 <script type="module" src="/js/posts/0028-plots-pyspark-example.js"></script>
 
-## 0. Overview
+## Overview
 
 This post about pyspark will work with one example that should be too big to work with pandas.
 
 Be sure to read <FancyLink linkText="Pyspark Intro" url="https://villoro.com/blog/pyspark-intro/" dark="true"/> before proceding with this post.
 
-## 1. Get data
+## Get data
 
 For this example we need to download a table that is really big.
 We would use open data from <FancyLink linkText="Catalunya" url="https://en.wikipedia.org/wiki/Catalonia" dark="true"/>.
@@ -41,7 +41,7 @@ To download first click the `Exporta` button then `CSV per a Excel`.
 
 ![Cat weather data](../../images/posts/2019/0028-cat_weather_data.jpg)
 
-## 2. Work with pandas
+## Work with pandas
 
 Usually the first things is to read a chunk of data with:
 
@@ -59,7 +59,7 @@ But if you try to read the whole file you will probably run out of memory.
 But fear not, you can work with pyspark which way less memory.
 I was able to everything in my computer with only 16 GB of RAM.
 
-## 3. Check data
+## Check data
 
 You can read the whole table with spark and it will be really fast (only some seconds):
 
@@ -90,13 +90,13 @@ sdf.write.format("parquet").mode("overwrite").save("weather_data.parquet")
 > [!tip]
 > Remember to load the dataframe from the `parquet` file to see the performance improvement.
 
-## 4. Read data
+## Read data
 
 Now is possible to do things like counting the rows or the number of unique stations without spending too much time.
 
 <canvas id="count_time_by_format" style="width:100%;height:250px;"></canvas>
 
-### 4.1. Explore possible partitions
+### Explore possible partitions
 
 It is a good idea to store dataframe in parquet by partitions.
 Usually they are partitioned by `date`.
@@ -105,7 +105,7 @@ But what is important is that you partition by a column that you will usually fi
 > [!warning]
 > You should never choose a partition column that has a lot of unique values since it will mean a lot of files.
 
-#### 4.1.1. Using station column
+#### Using station column
 
 By counting the number of rows by station we can see that:
 
@@ -116,12 +116,12 @@ So this is a good column to use for partitions
 
 <canvas id="partition_station" style="width:100%;height:300px;"></canvas>
 
-#### 4.1.2. Using variable column
+#### Using variable column
 
 This is another valid column for partition.
 But since we are going to do analysis filtering by station it is better to partition by `station`.
 
-#### 4.1.3 Using both station and variable column
+#### Using both station and variable column
 
 In this case the results are worst.
 The problem is that using to partitions is only useful if there are really a lot of rows.
@@ -134,7 +134,7 @@ In our case it ends up using **2 times the space disk** as the file partitioned 
 | variables           |                26 |               - |                  - |
 | station + variables |              2893 |            4.44 |               60.6 |
 
-## 5. Explore data
+## Explore data
 
 Now that we have the data properly stored let's do some exploration.
 First remember to load the data from the partitioned file.
@@ -145,7 +145,7 @@ If we take a look at basic operations we can see that the performance is similar
 
 However if we work with data from one partition the performance will be way better.
 
-### 5.1. Explore one station
+### Explore one station
 
 First let's explore the table with the definitions of the stations.
 Since I have a home at a small town called `Ulldemolins` let's try to find it.
@@ -181,7 +181,7 @@ Now if we do a count of this new table with `ulldemolins.count()` we can see tha
 The thing is that spark is only accessing one partition so it does not need to load a lot of data.
 It is only working with 2.8 million rows which is only 0.78% of the original data (360 million rows).
 
-### 5.2. Explore temperatures of one station
+### Explore temperatures of one station
 
 Let's keep only max temperatures (encoded as `Tx`) and min temperatures (as `Tn`).
 To filter it you can:
@@ -225,7 +225,7 @@ Some thoughts about the plot:
 
 Let's check it out.
 
-#### 5.2.1 Explore problem with temperatures
+#### Explore problem with temperatures
 
 Let's create a column with the `month` and one with the `day` in order to pivot the table.
 
@@ -248,7 +248,7 @@ And now the problem looks obvious.
 The data from the first 12 days is odd it is like it has been turned 90 degrees.
 And it is indeed because we **parsed incorrectly** by confusing `months` and `days`.
 
-#### 5.2.2. Explore data parsing it correctly
+#### Explore data parsing it correctly
 
 The only thing needed to fix the problem is to pass `day=True` to the function `pd.to_datetime`.
 So the `udf` should look like:

--- a/src/content/blog/0029-luigi.mdx
+++ b/src/content/blog/0029-luigi.mdx
@@ -12,7 +12,7 @@ tags: [Tools, Orchestration]
 draft: false
 ---
 
-## 1. What is Luigi
+## What is Luigi
 
 Luigi is a **Python** package that helps you build complex pipelines of batch jobs.
 It handles dependency resolution, workflow management, visualization, handling failures, command line integration, and much more.
@@ -26,9 +26,9 @@ You can install it directly with **pip**:
 pip install luigi
 ```
 
-## 2. Usage
+## Usage
 
-### 2.1. How it works
+### How it works
 
 **Luigi** work with tasks that are defined with classes that extend the `luigi.Task` class.
 The basic usage is to overwrite the `run` function (with what to do) and the `output` (with the file that will output).
@@ -54,7 +54,7 @@ class ReportTask(luigi.Task):
 
 This task will write a file called `output.txt` with the execution datetime.
 
-### 2.2. Basic example
+### Basic example
 
 For a real example tasks should also have dependencies.
 
@@ -173,7 +173,7 @@ python master.py
 
 And you should see how **Luigi** completes the 3 tasks.
 
-### 2.3. Luigi server
+### Luigi server
 
 If you go to `localhost:8082` you can see luigi server.
 
@@ -192,7 +192,7 @@ It is also possible view the dependency graph created with `D3`.
 
 ![Luigi Pipeline D3](../../images/posts/2020/0029-luigi_pipeline_d3.jpg)
 
-## 3. Using task templates
+## Using task templates
 
 The best way to orchestrate tasks in a fault tolerant way is by having a script (or package) for each task.
 This is the same as the last example where there ware `report.py` and `register.py` scripts.
@@ -354,14 +354,14 @@ class ReportTask(StandardTask):
             stream.write(datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
 ```
 
-## 4. Automatically run luigi
+## Automatically run luigi
 
 If you want a process always running and to be restarted on failure you should use **supervisor**.
 You should you use it for `luigid`.
 
 For running the tasks themselves **Luigi** does not have a scheduler but you can use **cron** instead.
 
-### 4.1. Install supervisor
+### Install supervisor
 
 First install it with:
 
@@ -418,7 +418,7 @@ sudo supervisorctl status
 
 If there are no errors you can start using **Luigi**.
 
-### 4.2. Create a virtual environment
+### Create a virtual environment
 
 First install **virtualenv** with:
 
@@ -444,7 +444,7 @@ source /home/ubuntu/venv/vtasks/bin/activate
 
 And `deactivate` to deactivate the environment.
 
-### 4.3. Script file to run luigi
+### Script file to run luigi
 
 Let's create the `run_luigi.sh` file with:
 
@@ -495,7 +495,7 @@ In order to run this you should give it executable permissions with:
 chmod +x /home/ubuntu/run_luigi.sh
 ```
 
-### 4.4. Running luigi tasks with cron
+### Running luigi tasks with cron
 
 The best way to run **Luigi** automatically is using cron.
 

--- a/src/content/blog/0030-cmder.mdx
+++ b/src/content/blog/0030-cmder.mdx
@@ -13,12 +13,12 @@ draft: false
 import cmderDefault from "../../images/posts/2020/0030-cmder_defualt.png";
 import cmderMain from "../../images/posts/2020/0030-cmder.png";
 
-## 0. Overview
+## Overview
 
 **Cmder** is a software package created out of pure frustration over the absence of nice console emulators on Windows.
 It is based on amazing software, and spiced up with the Monokai color scheme and a custom prompt layout, looking sexy from the start.
 
-## 1. Installation
+## Installation
 
 You can download from the <FancyLink linkText="Cmder" url="https://cmder.app/"/>.
 I advise you install the version with git.
@@ -31,7 +31,7 @@ Then open the `.exe` file (`C:\cmder_mini\Cmder.exe`) to start using it.
 > [!tip]
 > You can right click the `.exe` file and pin it to the task bar.
 
-## 2. Setting it as the default terminal
+## Setting it as the default terminal
 
 Open the **cmder** settings with `WIN` + `ALT` + `P`.
 Then go to `Integration` / `Default term` and mark `Force conEmu as default terminal for console applications`.
@@ -44,7 +44,7 @@ Then go to `Integration` / `Default term` and mark `Force conEmu as default term
 
 After that any operation that opens the terminal or the powershell will open `cmder`.
 
-## 3. Features
+## Features
 
 One of the best features is that most Linux commands (like `ls`) work here as well as the windows ones (like `dir`).
 So for example, no more problems with `cls` vs `clear` both work here!

--- a/src/content/blog/0031-poetry.mdx
+++ b/src/content/blog/0031-poetry.mdx
@@ -16,17 +16,17 @@ draft: false
 > [!danger]
 > **DISCLAIMER:** A lot has changed since I wrote this. Even though `Poetry` still works, I suggest using `uv` instead. See <FancyLink linkText="Exploring Astral's Fast Python Tools: uv and ruff" url="https://villoro.com/blog/astral-tools-uv-and-ruff/" dark="true"/>. I'm keeping this here for reference.
 
-## 0. Overview
+## Overview
 
 Poetry is a python packaging and dependency manager.
 It makes it really easy to manage packages while using environments under the hood.
 It also allows build and publishing packages to PyPI (or other sites).
 
-## 1. Alternatives. Why Poetry?
+## Alternatives. Why Poetry?
 
 Before viewing why **Poetry** is a good solution let's check the more common alternatives.
 
-### 1.1. Raw
+### Raw
 
 The easiest and least elegant way of handling dependencies is by simply installing all packages in the main environment.
 In other words this means installing packages only using:
@@ -52,13 +52,13 @@ This method will have some major problems:
 > [!note]
 > It is true that you can create a `requirements_dev.txt` file to handle development dependencies but you will need to manually maintain it.
 
-### 1.2. Virtualenv / Conda
+### Virtualenv / Conda
 
 With both `Virtualenv` or `Conda` it is possible to create **environment**. This will allow to have different versions for different projects.
 
 But except from that point there will still be the other problems.
 
-## 2. How Poetry works?
+## How Poetry works?
 
 With **Poetry** you create a project (or import one) and it automatically creates/uses a virtual environment under the hood.
 
@@ -91,9 +91,9 @@ build-backend = "poetry.masonry.api"
 
 Finally the `poetry.lock` is a snapshot with the exact versions install. It can be updated from the `pyproject.toml`.
 
-## 3. Creating a project
+## Creating a project
 
-### 3.1. Init a new project
+### Init a new project
 
 The first thing to do with python is to create a new project. You can do it with:
 
@@ -102,7 +102,7 @@ poetry new projectname
 # Replace projectname for the name you want
 ```
 
-### 3.2. Project structure
+### Project structure
 
 Creating a new project will create the following files:
 
@@ -119,11 +119,11 @@ Creating a new project will create the following files:
 
 There will be a dummy test inside the `tests` folder using the `pytest` package.
 
-## 4. Managing dependencies
+## Managing dependencies
 
 The idea is to use poetry to add or remove packages and let it handle the `pyproject.toml` file.
 
-### 4.1. Add/remove packages
+### Add/remove packages
 
 To add or remove packages you can use:
 
@@ -155,7 +155,7 @@ Which translates to `>=0.25.0 <1.0.0`
 
 You can check all the possible ways in the <FancyLink linkText="Poetry docs" url="https://python-poetry.org/docs/dependency-specification/#version-constraints" company="poetry"/>.
 
-### 4.2. Install update dependencies
+### Install update dependencies
 
 Once there is a `pyproject.toml` file you can install/update all the specified dependencies.
 
@@ -173,7 +173,7 @@ poetry install --no-dev
 > [!info]
 > Both commands will create a the `poetry.lock` file with a snapshot of the installed packages (or update it if already present).
 
-### 4.3. See dependencies
+### See dependencies
 
 With poetry you easily see the dependencies of your project as well as the dependencies of those dependencies.
 
@@ -189,11 +189,11 @@ As an example:
 
 ![Poetry Show](../../images/posts/2020/0031-poetry_show.png)
 
-### 4.4. Check
+### Check
 
 With `poetry check` you can check if the `pyproject.toml` file has any errors.
 
-## 5. Running code with Poetry
+## Running code with Poetry
 
 Since poetry uses a virtual environment and you are not activating/sourcing it has commands to actually work with the environment.
 
@@ -216,7 +216,7 @@ poetry run luigid
 poetry run python src/master.py
 ```
 
-## 6. Create and publish packages
+## Create and publish packages
 
 You can use poetry to build python packages with:
 
@@ -232,7 +232,7 @@ And then you can also upload it to `PyPI` with:
 poetry publish
 ```
 
-## 7. Poetry compatibility
+## Poetry compatibility
 
 Finally you can use poetry and allow other people to use the old `requirements.txt` file.
 
@@ -242,7 +242,7 @@ You will only need to export it with:
 poetry export -f requirements.txt > requirements.txt
 ```
 
-## 8. More info
+## More info
 
 If you want to read more about poetry check out the following links:
 

--- a/src/content/blog/0032-pre_commit.mdx
+++ b/src/content/blog/0032-pre_commit.mdx
@@ -12,7 +12,7 @@ tags: [Tools]
 draft: false
 ---
 
-## 1. What is pre-commit
+## What is pre-commit
 
 With pre-commit you can automate some repetitive tasks before doing a `commit` on a **git** repository.
 It is useful for identifying simple issues before submission to code review.
@@ -21,7 +21,7 @@ For example with **pre-commit** you can point out issues in code such as missing
 
 **Pre-commit** can work with **any development language** even though is a python package.
 
-## 2. Installation
+## Installation
 
 To install you can simply run:
 
@@ -29,7 +29,7 @@ To install you can simply run:
 pip install pre-commit
 ```
 
-## 3. Configuration
+## Configuration
 
 Once you have the package installed you need the file `.pre-commit-config.yaml` with the hooks you need.
 
@@ -58,7 +58,7 @@ Once you are in a repository that has the `.pre-commit-config.yaml` file you can
 pre-commit install
 ```
 
-## 4. Usage
+## Usage
 
 By default `pre-commit` will run only on the stagged files. You can check all the files the first time you install it with:
 
@@ -68,7 +68,7 @@ pre-commit run --all-files
 
 After that each time you try to do a commit `pre-commit` will run all hooks and will prevent you from commiting simple issues.
 
-## 5. Updating hooks
+## Updating hooks
 
 You can update all `pre-commit` hooks with:
 
@@ -76,7 +76,7 @@ You can update all `pre-commit` hooks with:
 pre-commit autoupdate
 ```
 
-## 6. Continuous integration (CI)
+## Continuous integration (CI)
 
 It is a good idea to run `pre-commit` on your CI to check that nobody is pushing code with errors.
 
@@ -92,7 +92,7 @@ If you want to only run it on the files that have changed just do:
 pre-commit run --from-ref origin.HEAD --to-ref HEAD
 ```
 
-## 7. Useful hooks
+## Useful hooks
 
 There are some default hooks defined <FancyLink linkText="Pre-commit hooks" url="https://github.com/pre-commit/pre-commit-hooks" dark="true"/>.
 

--- a/src/content/blog/0033-python_environment_config.mdx
+++ b/src/content/blog/0033-python_environment_config.mdx
@@ -10,7 +10,7 @@ tags: [Python, Tools]
 draft: false
 ---
 
-## 1. Using a git provider
+## Using a git provider
 
 The first thing to do is select a **GIT** hosting service. The most popular are:
 
@@ -22,7 +22,7 @@ The first thing to do is select a **GIT** hosting service. The most popular are:
 Those services host your **GIT** repository and allow you to interact with your team.
 There are some methodologies that you can follow when working with **GIT**, my suggestion is that you use **gitflow**: <FancyLink linkText="Using gitflow for code control" url="https://villoro.com/blog/using-gitflow" dark="true"/>
 
-### 1.1. Protecting branches
+### Protecting branches
 
 As I suggested it is a good practice to use pull request to integrate changes to the `develop` and/or `master` branches.
 Since people can do mistakes you should set some branch protection.
@@ -31,7 +31,7 @@ As an example this is how you prevent the `master` branch to be deleted or to ha
 
 ![Github branch protection](../../images/posts/2020/0033-github_branch_protection.png)
 
-## 2. Install a custom terminal
+## Install a custom terminal
 
 If you are developing you almost certainly will also be using a terminal.
 If you are a **Windows** the default terminal lacks a lot of nice features so I you can install a custom terminal.
@@ -55,19 +55,19 @@ rf=python src/index.py
 > [!warning]
 > You should append that to the end of the `user_aliases.cmd` file. **Do not remove the existing content**.
 
-## 3. Connect to your GIT hosting service
+## Connect to your GIT hosting service
 
 There are different ways to connect to the GIT hosting service.
 The more secure one is by setting up a **SSH** key: <FancyLink linkText="Using git with SSH" url="https://villoro.com/blog/git-with-ssh" dark="true"/>
 
-### 3.1. GIT Client
+### GIT Client
 
 You can work with **GIT** with your terminal or by using a program.
 In my case I like using <FancyLink linkText="Sublime Merge" url="https://www.sublimemerge.com/"/>.
 
 It works in `Windows`, `Mac` and `Linux` and uses only **GIT** commands under the hood.
 
-## 4. Installing an IDE
+## Installing an IDE
 
 In order to develop you need to write text files.
 You can do it with any text editor but there IDEs that have a lot of nice features.
@@ -77,7 +77,7 @@ The one I like the most is <FancyLink linkText="Sublime Text 3" url="https://www
 It is also important to install extensions for your IDE that can help you.
 As an example you can use `black` with `sublack` for **Sublime Text**: <FancyLink linkText="Black for code formatting" url="https://villoro.com/blog/black-code-formatting" dark="true"/>
 
-## 5. Create package with poetry
+## Create package with poetry
 
 Then you need to create your project. The important part is that you use some kind of virtual environment / package control like:
 
@@ -88,7 +88,7 @@ Then you need to create your project. The important part is that you use some ki
 I find that **Poetry** is the easiest and the one that has more useful features.
 You can read more about it here: <FancyLink linkText="Poetry package manager" url="https://villoro.com/blog/poetry-python-package-manager" dark="true"/>
 
-## 6. Pre-commit
+## Pre-commit
 
 <FancyLink linkText="Git Hooks" url="https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks"/> are a good way to automate some tasks.
 There are multiple way of using them. What I suggest is that you use `pre-commit`: <FancyLink linkText="Using Pre-commit to automate tasks" url="https://villoro.com/blog/pre-commit" dark="true"/>
@@ -101,7 +101,7 @@ My bare minimum for `pre-commit` with python is to add:
 * black
 * flake8
 
-## 7. CI Integration
+## CI Integration
 
 **Continuous Integration (CI)** allows to automate tasks such as testing and deploying.
 If you don't know what it is you can read it <FancyLink linkText="Continuous integration" url="https://www.atlassian.com/continuous-delivery/continuous-integration"/>.
@@ -113,7 +113,7 @@ There are a lot of **CI** providers, the more famous are:
 * <FancyLink linkText="Circle CI" url="https://circleci.com/" dark="true"/>
 * <FancyLink linkText="Gitlab" url="https://gitlab.com/"/>
 
-## 8. Deploying
+## Deploying
 
 Finally you might want to deploy your code.
 

--- a/src/content/blog/0034-pyspark_java_udf.mdx
+++ b/src/content/blog/0034-pyspark_java_udf.mdx
@@ -12,7 +12,7 @@ draft: false
 
 <script type="module" src="/js/posts/0034-plots-spark-java-udf.js"></script>
 
-## 0. Problem
+## Problem
 
 When using **spark** it's always advised to use the spark functions.
 However sometimes we need to use more advanced functions or we need external libraries.
@@ -27,7 +27,7 @@ The library is implemented in multiple languages:
 
 In this post we will explore different options for using this function with spark.
 
-## 1. Creating a python UDF
+## Creating a python UDF
 
 The first option is to create a python **UDF** using the **h3** python library.
 Before creating the UDF we can try the library with:
@@ -65,9 +65,9 @@ Once it's defined it can be called with:
 )
 ```
 
-## 2. Use a Java function with spark
+## Use a Java function with spark
 
-### 2.1. Use H3 directly
+### Use H3 directly
 
 The first thing needed to work with the **Java H3** library is to download the `jar`.
 It can be downloaded from <FancyLink linkText="Maven/h3" url="https://mvnrepository.com/artifact/com.uber/h3" company="default" dark="true"/>.
@@ -87,14 +87,14 @@ h3.geoToH3Address(0.0, 0.0, 8)
 However it is not possible to create a **UDF** using the java instance.
 The problem is that it's a java object so it can't be pickled.
 
-### 2.2. Create a java callable function
+### Create a java callable function
 
 Let's create a simple **java** `static` function that we can use without needing to create an instance.
 
 We can create the file `SimpleH3.java` inside the path `/com/villoro/` (so that it's better organized).
 Remember to define the `package` so that it matches the path.
 
-#### 2.2.1 Create the java file
+#### Create the java file
 
 <TerminalOutput color="stone">
   /com/villoro/SimpleH3.java
@@ -139,7 +139,7 @@ But the next times it will reuse the same instance.
 > [!tip]
 > **Lazy instantiation** will make the code faster.
 
-#### 2.2.2. Compile the code
+#### Compile the code
 
 Once we have our `java` code we need to compile it.
 
@@ -152,7 +152,7 @@ Then you can compile the code with:
 javac -cp "jars/h3.jar" com\villoro\*.java
 ```
 
-#### 2.2.3. Create the jar
+#### Create the jar
 
 To create the `jar` we can simple specify that we want to create the `SimpleH3.jar` with all `.class` files from `com\villoro\` with:
 
@@ -162,7 +162,7 @@ jar cvf SimpleH3.jar com\villoro\*.class
 
 Once you created the `jar`, remember to copy it to `$JAVA_HOME/jars`.
 
-#### 2.2.4. Call the static java function with spark
+#### Call the static java function with spark
 
 We can do something similar to call the new static function:
 
@@ -174,14 +174,14 @@ spark.sparkContext._jvm.com.villoro.SimpleH3.toH3Address(0.0, 0.0, 8)
 However this can't still be pickled since it's a java class.
 So we can't create a **UDF** with python.
 
-## 3. Create a Java UDF
+## Create a Java UDF
 
 The solution will be to create the **UDF** with **java**.
 
 The first thing you will need is to get the `spark-sql.jar` from `$JAVA_HOME/jars` and copy it to `com\villoro\`.
 Without this `jar` you won't be able to compile the **UDF** with **java**.
 
-### 3.1. Create the java function
+### Create the java function
 
 Then to create the **UDF** you need to implement one of the `UDFX` class.
 Since it will have three imputs we will use `UDF3`.
@@ -228,7 +228,7 @@ public class toH3AddressUDF implements UDF3<Double, Double, Integer, String> {
 }
 ```
 
-### 3.2. Compile the code
+### Compile the code
 
 The command is really similar to the one we used before:
 
@@ -239,7 +239,7 @@ javac -cp "jars/h3.jar;jars/spark-sql.jar" com\villoro\*.java
 > [!warning]
 > Make sure the name of the `jars` you are importing match.
 
-### 3.3. Create the jar
+### Create the jar
 
 We can use exactly the same command as before:
 
@@ -249,7 +249,7 @@ jar cvf SimpleH3.jar com\villoro\*.class
 
 Once you created the `jar`, remember to overwrite it in `$JAVA_HOME/jars`.
 
-### 3.4. Call the java UDF with spark
+### Call the java UDF with spark
 
 Before calling the function we need to register it with:
 
@@ -277,7 +277,7 @@ spark.sql("""
 """).show()
 ```
 
-## 4. Performance results
+## Performance results
 
 In order to test it I created 6 datasets with different sizes.
 The total execution times for the `python udf` and `java udf` are:

--- a/src/content/blog/0035-ing_api.mdx
+++ b/src/content/blog/0035-ing_api.mdx
@@ -10,7 +10,7 @@ tags: [Python, DE, API]
 draft: false
 ---
 
-## 1. ING Developer
+## ING Developer
 
 ING has a <FancyLink linkText="developer portal" url="https://developer.ing.com/openbanking/home"/> with instructions
 for accessing their APIs.
@@ -30,7 +30,7 @@ This post focus on the **Open Banking** API.
 > **Only accredited institutions will get the required credentials.**
 > I discovered after doing all the work and I'm sharing it in case anyone wants to try it and/or in case individuals can use it in the future.
 
-## 2. The Open Banking API
+## The Open Banking API
 
 At the moment of writing of this post there is not a lot that you can do with this API.
 Those are the 2 APIs you can use:
@@ -47,7 +47,7 @@ I also contacted their **support** and they told me they plan to allow users to 
 But there is no ETA for that.
 
 
-## 3. Open Banking API Sandbox
+## Open Banking API Sandbox
 
 This part follows the <FancyLink linkText="Getting Started with Open Banking API" url="https://developer.ing.com/openbanking/get-started/openbanking"/>.
 
@@ -77,7 +77,7 @@ pip install pycryptodome
 
 Let's break down the script in parts
 
-### 3.1. Digesting and signing
+### Digesting and signing
 
 You need to calculate the `SHA256` of some parts.
 That can be done with:
@@ -123,7 +123,7 @@ from base64 import b64encode
 b64encode(out).decode()
 ```
 
-### 3.2. Parameters
+### Parameters
 
 Now let's create the basic parameters:
 
@@ -147,7 +147,7 @@ headers = {
 }
 ```
 
-### 3.3. Getting the signature
+### Getting the signature
 
 In this step you need to encode with `SHA256` the composition of:
 * endpoint
@@ -180,7 +180,7 @@ def get_signature(method, endpoint, mdate, digest, req_id):
     return ",".join(signature)
 ```
 
-### 3.4. Doing the request
+### Doing the request
 
 Now we need to append the authorization as a header:
 
@@ -207,7 +207,7 @@ result = requests.request(
 )
 ```
 
-### 3.5. Getting the token
+### Getting the token
 
 This can be done with the code explained and using those params:
 
@@ -216,13 +216,13 @@ This can be done with the code explained and using those params:
 * body: `grant_type=client_credentials`
 
 
-## 4. Creating your app
+## Creating your app
 
 In this step you need to sign in to the <FancyLink linkText="ING developer portal" url="https://developer.ing.com/openbanking/auth/login"/>.
 
 Then you need to create an app.
 
-### 4.1. Generating your certificates
+### Generating your certificates
 
 You need to generate:
 
@@ -244,7 +244,7 @@ openssl x509 -req -sha256 -days 365 -in ing_http.csr -signkey ing_http.key -out 
 
 Then need to repeat the 3 steps but replacing `ing_http` by `ing_tls`.
 
-### 4.2. Getting a token with your API
+### Getting a token with your API
 
 You need to follow the same as before but changing some params:
 
@@ -254,7 +254,7 @@ You need to follow the same as before but changing some params:
 * tls_cert: `certificates/ing_tls.crt`
 * tls_key: `certificates/ing_tls.key`
 
-### 4.3. Doing a hello world
+### Doing a hello world
 
 Once you have the open you can subscribe to <FancyLink linkText="Showcase API" url="https://developer.ing.com/api-marketplace/marketplace/5f5106c4-3413-4b3c-890a-bb4cfa165dba/overview"/>.
 You will need to wait until your request is approved.
@@ -265,6 +265,6 @@ Once it is approved you can query the only endpoint to check that everything is 
 * endpoint: `/greetings/single`
 
 
-## 5. Next steps
+## Next steps
 
 Now you can wait with me until they add more APIs under the Open Banking 😢

--- a/src/content/blog/0036-regex.mdx
+++ b/src/content/blog/0036-regex.mdx
@@ -13,7 +13,7 @@ tags: [Python]
 draft: false
 ---
 
-## 1. Regex basics
+## Regex basics
 
 A regular expression, or **regex** for short, is a pattern describing a certain amount of text.
 The most simple regex is a regular string, like `hello` which will match the literal text `hello`.
@@ -23,7 +23,7 @@ As an example `ip.d` will match `ipad`, `ipod`, `ip@d` etc.
 
 If we want to only match `ipod` or `ipad` we can use `ip[ao]d`.
 
-### 1.1. Brackets `[]`
+### Brackets `[]`
 
 Brackets (`[` and `]`) are used for specifying which characters are allowed. It is similar to an **or** operator. As an example:
 
@@ -32,7 +32,7 @@ Brackets (`[` and `]`) are used for specifying which characters are allowed. It 
 * `[^a-c]`: anything but `a`, `b` or `c`
 * `[0-9a-fA-F]`: any number or any letter between `a` and `f` or between `A` and `F`. This represents hexadecimal
 
-### 1.2. Position
+### Position
 
 It is possible to specify matches based on the position with:
 
@@ -41,7 +41,7 @@ It is possible to specify matches based on the position with:
 
 For example `^ab` will only match the first `ab` in `ab abc ab` (<FancyLink linkText="Demo" url="https://regex101.com/r/TJzoA7/2"/>)
 
-### 1.3. Classes
+### Classes
 
 There are certain keywords that will match different types of characters.
 For example `\d` will match any digit (any of those `0123456789`).
@@ -55,7 +55,7 @@ The main classes available are:
 | `\w`  | Alphanumeric and/or `_`                 | <FancyLink linkText="w_example" url="https://regex101.com/r/IkIMMm/1"/> | `\W`    |
 | `\s`  | Whitespaces and equivalents (like tabs) | <FancyLink linkText="s_example" url="https://regex101.com/r/oSziKA/1"/> | `\S`    |
 
-### 1.4. Quantifiers
+### Quantifiers
 
 It is possible to specify how many times a letter or group (defined in the next section) should appear.
 
@@ -69,7 +69,7 @@ As an example we want the letter `a` + the letter `b` which should appear differ
 | `ab{2}`  | `a` + `b` exactly 2 times                       | <FancyLink linkText="example_ab{2}" url="https://regex101.com/r/TYBz4I/1"/>   |
 | `ab{2,5}`| `a` + `b` between 2 and 5 times (inclusive)     | <FancyLink linkText="example_ab{2,5}" url="https://regex101.com/r/b4oI9X/1"/> |
 
-### 1.5. Groups
+### Groups
 
 It is possible to define **groups** in regex.
 They are used to capture part of the text and are declared with parenthesis `()`.
@@ -80,7 +80,7 @@ We can use any regex inside the group. For example if we want to math `hello`:
 * `(?P<name>hello)`: same but giving the group a name (`name` in this case)
 * `(hello|bye):` **or** operator in groups.
 
-### 1.6. Boundaries
+### Boundaries
 
 It is possible to declare a boundary with `\b` (with the inverse `\B`).
 A boundary means that is surrounded with a non word type character.
@@ -96,7 +96,7 @@ It is easier to understand it with some examples:
 | `possible\B`   | Impossible to do                                                   | I'm possible :)                                                   | <span style="background-color:aquamarine;">possible</span>r | <FancyLink linkText="boundaries_4" url="https://regex101.com/r/jL4Lkv/1"/> |
 | `\Bpossible`   | Im<span style="background-color:aquamarine;">possible</span> to do | I'm possible :)                                                   | possibler                                                   | <FancyLink linkText="boundaries_5" url="https://regex101.com/r/bnTUnx/1"/> |
 
-### 1.7. Flags
+### Flags
 
 It is possible to change the behaviour of the regex with some flags:
 
@@ -104,7 +104,7 @@ It is possible to change the behaviour of the regex with some flags:
 * `(?m)`: **multi line**. When this is active the anchor `^` will be start of line instead of start of text (<FancyLink linkText="Demo" url="https://regex101.com/r/Ol3N99/1"/>)
 * `(?s)`: **single line**.
 
-### 1.8. Greedy vs lazy
+### Greedy vs lazy
 
 Imagine that we have the following text:
 
@@ -128,9 +128,9 @@ To sum up:
 > It can also be used with other quantifiers that are not the `+`.
 
 
-## 2. Regex with python
+## Regex with python
 
-### 2.1. `re` package
+### `re` package
 
 To use regex in **python** you first need to import the `re` package with
 
@@ -149,7 +149,7 @@ out = re.match(r"hello", "hello world")
 > [!tip]
 > When declaring regexs in python it is a good practise to declare them as **raw** strings with `r"regex"`
 
-### 2.2. `match` vs `search`
+### `match` vs `search`
 
 We have use `re.match` since it's faster. However this only looks at the beginning of the string.
 To do a more in deep search we can use `re.search`.
@@ -169,7 +169,7 @@ The results would be:
 | `r"world"` | ❌       | ✔️       |
 | `r"bye"`   | ❌       | ✔️       |
 
-### 2.3. `re.compile`
+### `re.compile`
 
 If we plan to reuse the same regex we can compile it with `regex = re.compile(regex)`:
 
@@ -187,7 +187,7 @@ regex.search("hello world")
 
 The advantage is that a **compiled regex is faster** than a non-compiled one.
 
-### 2.4. Working with groups
+### Working with groups
 
 Imagine that we have the following file names:
 
@@ -200,7 +200,7 @@ filenames = [
 ]
 ```
 
-#### 2.4.1. Unnamed groups
+#### Unnamed groups
 
 It looks more or less clear that we can extract some data from those names:
 
@@ -214,7 +214,7 @@ out.groups()
   \> ('AABBCCDD', '2020', '01')
 </TerminalOutput>
 
-#### 2.4.2. Named groups
+#### Named groups
 
 We can use named groups to better extract the data
 
@@ -247,7 +247,7 @@ for filename in filenames:
 </TerminalOutput>
 
 
-## 3. Regex with pandas
+## Regex with pandas
 
 There are multiple functions in **pandas** that can be used with **regex**. They are:
 
@@ -273,7 +273,7 @@ queries = [
 df = pd.DataFrame(queries, columns=["query"])
 ```
 
-### 3.1. `series.str.count`
+### `series.str.count`
 
 In this case we want to `count` the number of queries that come from the `users` table.
 It doesn't matter if the schema is specified or not. It can be done with:
@@ -288,7 +288,7 @@ df["query"].str.count(r"\s+FROM\s+(\w+\.)?users\b")
   0
 </TerminalOutput>
 
-### 3.2. `series.str.replace`
+### `series.str.replace`
 
 We can use this for deleting the renamings (like ` AS cnt`):
 
@@ -302,7 +302,7 @@ df["query"].str.replace(r"\s+AS\s+\w+\b", "", regex=True)
   `SELECT city, count(1) FROM orders GROUP BY 1`
 </TerminalOutput>
 
-### 3.3. `series.str.match`
+### `series.str.match`
 
 In this case we can look which queries are selecting all columns (`SELECT * FROM`):
 
@@ -316,7 +316,7 @@ df["query"].str.match(r"(?i)(SELECT)\s+\*\s+(?i)(FROM)")
   False
 </TerminalOutput>
 
-### 3.4. `series.str.contains`
+### `series.str.contains`
 
 Similar to the `replace` example, let's get the queries that have a rename `AS x`:
 
@@ -330,7 +330,7 @@ df["query"].str.contains(r"\s+AS\s+\w+")
   False
 </TerminalOutput>
 
-### 3.5. `series.str.findall`
+### `series.str.findall`
 
 We can use this for getting a list with all words that have between 5 and 8 letters:
 
@@ -347,7 +347,7 @@ df["query"].str.findall(r"\w{5,8}")
 > [!note]
 > Note that the output is one list per row.
 
-### 3.6. `series.str.split` / `series.str.rsplit`
+### `series.str.split` / `series.str.rsplit`
 
 In this case let's split the query in 2 parts, all before the `FROM` and all after it:
 
@@ -361,7 +361,7 @@ df["query"].str.split(r"\s+(?i)from\s+")
   [`SELECT city, count(1)`, `orders GROUP BY 1`]
 </TerminalOutput> 
 
-### 3.7. `series.str.extract`
+### `series.str.extract`
 
 With this function we can extract data from groups.
 The output of this function is a **DataFrame** where each group is a column.
@@ -394,7 +394,7 @@ The regex used in this example might be a little bit complex, let's analyze it b
 * `(?P<table>\w+)\b`: Capturing group named `table` made only with words and that has a right boundary
 
 
-## 4. Regex with redshift
+## Regex with redshift
 
 In **redshift** there are 4 string functions that work with regular expressions (regex).
 They are:

--- a/src/content/blog/0037-reading_from_redshift.mdx
+++ b/src/content/blog/0037-reading_from_redshift.mdx
@@ -16,7 +16,7 @@ draft: false
 
 <script type="module" src="/js/posts/0037-plots-reading-from-redshift.js"></script>
 
-## 0. The problem
+## The problem
 
 One of the best ways to start analyzing business data is by using a **datawarehouse** (dwh).
 For companies using the AWS stack **redshift** is the default option for a dwh.
@@ -37,7 +37,7 @@ In this post we will focus on how to consume data efficiently as **pandas** data
 This is because in our case a lot of bots are doing this.
 The biggest example here might be jobs that are running Machine Learning (ML) pipelines.
 
-## 1. Using direct queries
+## Using direct queries
 
 The most basic option for reading data from redshift is to connect directly to the database.
 As an example this can be done with **SQL alchemy**: <FancyLink linkText="SQL Alchemy with python" url="https://villoro.com/blog/sql-alchemy-python" dark="true"/>
@@ -49,7 +49,7 @@ The problem with such options is that it puts some pressure on **redshift** sinc
 * handle the queue of queries (which could become quite big)
 * execute the query and deliver the data
 
-## 2. Unloading to parquets
+## Unloading to parquets
 
 One alternative to doing direct queries is to **unload data from redshift**.
 This is done by passing a query to the `UNLOAD` command so that redshift can export the result to **S3**.
@@ -63,9 +63,9 @@ But by doing that the export will be slower and more computationally costly for 
 
 So, if we end up with multiple parquet files, how should we read them?
 
-## 3. Reading parquets as pandas dataframes
+## Reading parquets as pandas dataframes
 
-### 3.1. Using pandas read parquet (`pandas_read`)
+### Using pandas read parquet (`pandas_read`)
 
 The first option is to simply use `pandas.read_parquet` function and read all files in a loop.
 This can be done with:
@@ -89,7 +89,7 @@ df = pd.concat(dfs)
 
 If we need to filter based on a column with this option we would do it after creating the pandas dataframe.
 
-### 3.2. Using pyarrow read table (`pyarrow_single_read`)
+### Using pyarrow read table (`pyarrow_single_read`)
 
 Another option is to read each file with **pyarrow** instead.
 This would by done by:
@@ -112,7 +112,7 @@ df = pd.concat(dfs)
 
 If we need to filter based on a column with this option we would do it after creating the pandas dataframe.
 
-### 3.3. Using pyarrow parquet dataset (`pyarrow_parquet_ds_read`)
+### Using pyarrow parquet dataset (`pyarrow_parquet_ds_read`)
 
 Another option is to use the `ParquetDataset` from **pyarrow**.
 With this we only need to specify the folder where the parquets are stored and **pyarrow** will pick all the files.
@@ -140,7 +140,7 @@ mfilters = [
 dataset = pq.ParquetDataset(path, validate_schema=False, filter=mfilters)
 ```
 
-### 3.4. Using pyarrow dataset (`pyarrow_ds_read`)
+### Using pyarrow dataset (`pyarrow_ds_read`)
 
 With the release of <FancyLink linkText="Pyarrow 3.0.0" url="https://arrow.apache.org/release/3.0.0.html" company="arrow" dark="true"/> (released on 2021-01-26) a new way of reading parquets was introduced.
 The idea is to use the new `pyarrow.dataset` to create a table which can then be transformed into a **pandas** dataframe.
@@ -167,7 +167,7 @@ As an example this can be done with:
 table = dataset.to_table(filter=ds.field("p_creation_date") >= "2021-04-29")
 ```
 
-## 4. Datasets for testing
+## Datasets for testing
 
 For testing the different options we are going to use <FancyLink linkText="US accidents dataset" url="https://www.kaggle.com/sobhanmoosavi/us-accidents"/> from kaggle.
 This is a 1 GB dataset (stored as `csv`).
@@ -178,12 +178,12 @@ In order to test different set ups we are going to store this dataset in 3 diffe
 1. One parquet by month
 2. Multiple parquets by month
 
-### 4.1. Dataset 0 (single parquet)
+### Dataset 0 (single parquet)
 
 This first dataset is created by exporting all the data as **one single parquet file**.
 This is the kind of dataset we would have if we were to do only one export with all the data we want to consume.
 
-### 4.2. Dataset 1 (One parquet by month)
+### Dataset 1 (One parquet by month)
 
 This dataset contains only one parquet per month.
 Those parquets are stored in subfolders following the **hive** partitioning:
@@ -202,7 +202,7 @@ Those parquets are stored in subfolders following the **hive** partitioning:
 This represents a partitioned dataset that doesn't have a lot of files.
 This is what we would have if we were doing periodical unloads into each subfolder and then later combining the output into fewer files.
 
-### 4.3. Dataset 2 (Multiple parquets by month)
+### Dataset 2 (Multiple parquets by month)
 
 This last dataset is similar to the previous one but with multiple files per partition.
 We used the `state` column to easily create around 50 files per partition.
@@ -210,9 +210,9 @@ We used the `state` column to easily create around 50 files per partition.
 This represents a dataset with a lot of files.
 This is what we would have if we were doing periodical unloads into each subfolder
 
-## 5. Testing all options
+## Testing all options
 
-### 5.1. Reading from a single parquet (dataset 0)
+### Reading from a single parquet (dataset 0)
 
 The first test is to compare the reading of one single file using the different methods.
 
@@ -220,7 +220,7 @@ The first test is to compare the reading of one single file using the different 
 
 We see that the the **pyarrow** datasets options performs a little bit better.
 
-### 5.2. Reading from data paritioned (datasets 1 and 2)
+### Reading from data paritioned (datasets 1 and 2)
 
 In this case we are comparing what would happen if we were reading partitioned data.
 There are 2 different readings that we are testing:
@@ -241,7 +241,7 @@ Here the differences are even bigger.
 
 <canvas id="dataset_1" style="width:100%;height:400px;"></canvas>
 
-### 5.3. Comparing best options
+### Comparing best options
 
 Let's zoom in and compare the best options (`pyarrow_ds_read` and `pyarrow_parquet_ds_read`) and compare both partitioned datasets.
 
@@ -250,7 +250,7 @@ Let's zoom in and compare the best options (`pyarrow_ds_read` and `pyarrow_parqu
 Here it seems like the new `pyarrow.dataset` only performs better with a dataset with a lot of files.
 If we have a small number of files it performs slightly worse.
 
-### 5.4. Reading using row groups
+### Reading using row groups
 
 In this case we want to do another test where we apply 2 filters at the same time:
 
@@ -269,7 +269,7 @@ That means that **pyarrow** is only retrieving some `row_groups` and therefore l
 
 You can find more info about how parquet files are written in <FancyLink linkText="How Parquet Files are Written" url="http://cloudsqale.com/2020/05/29/how-parquet-files-are-written-row-groups-pages-required-memory-and-flush-operations/" company="default" dark="true"/>.
 
-## 6. Conclusions
+## Conclusions
 
 To sum it up doing unloads is a more efficient way of consuming large quantities of data from redshift.
 

--- a/src/content/blog/0038-poetry_versioning.mdx
+++ b/src/content/blog/0038-poetry_versioning.mdx
@@ -16,7 +16,7 @@ draft: false
 > [!danger]
 > **DISCLAIMER:** A lot has changed since I wrote this. Even though `Poetry` still works, I suggest using `uv` instead. See <FancyLink linkText="Exploring Astral's Fast Python Tools: uv and ruff" url="https://villoro.com/blog/astral-tools-uv-and-ruff/" dark="true"/>. I'm keeping this here for reference.
 
-## 0. The problem
+## The problem
 
 Handling project version numbers is painful and can be tedious if not automated.
 To make matters worse, we often need to update the version in multiple files.
@@ -25,7 +25,7 @@ This post will explain how to simplify this process and how to automate it.
 It only focuses on how to manage it using `poetry` since it's the tool I recommend for handling virtual environments.
 If you need to set up **Poetry**, see: <FancyLink linkText="Poetry python package manager" url="https://villoro.com/blog/poetry-python-package-manager" dark="true"/>
 
-## 1. `poetry-bumpversion`
+## `poetry-bumpversion`
 
 With <FancyLink linkText="Poetry-bumpversion" url="https://pypi.org/project/poetry-bumpversion/"/>, we can easily update the package version.
 
@@ -40,7 +40,7 @@ In short with `semver` the version consists of three numbers (`M.m.p`) where:
 * `m`: minor version. Represents relevant changes
 * `p`: patch version. For fixes without new functionality
 
-### 1.1. Installing `poetry-bumpversion`
+### Installing `poetry-bumpversion`
 
 You can do it with:
 
@@ -55,7 +55,7 @@ poetry self add poetry-bumpversion
 poetry install
 ```
 
-### 1.2. Updating the version in `pyproject.toml`
+### Updating the version in `pyproject.toml`
 
 You can do it by running:
 
@@ -65,7 +65,7 @@ poetry version minor
 poetry version patch
 ```
 
-### 1.3. Updating other files
+### Updating other files
 
 Frequently you will have other files that declare the version.
 For example, you could have `dbt_project.yml` if you are using `dbt`.
@@ -82,7 +82,7 @@ search = "version: '{current_version}'"
 replace = "version: '{new_version}'"
 ```
 
-## 2. Automatically validate versions
+## Automatically validate versions
 
 The idea is to create a GitHub action that automatically validates that the version is updated.
 This way you can decide if you want to increase the `major`, `minor`, or `patch` digit.
@@ -249,7 +249,7 @@ The way this works is by:
 2. Extracting the version from the current branch in the pull request
 3. If `current_version <= main_version`, then fail
 
-## 3. Automatically tag versions
+## Automatically tag versions
 
 In order to keep better tracking of the package version, we will be tagging all commits to `main` with their version.
 We can do that with the following GitHub action:
@@ -295,11 +295,11 @@ jobs:
             })
 ```
 
-## 4. Environment variables in github actions
+## Environment variables in github actions
 
 One of the ways of passing information from one step in a GitHub action to another is by using environment variables.
 
-### 4.1. Storing data in an environment variable
+### Storing data in an environment variable
 
 There is a couple of ways of storing data in an environment variable.
 This first one would be with an `echo` like:
@@ -323,7 +323,7 @@ def set_output(name, value):
         print(f"{name}={value}", file=fh)
 ```
 
-### 4.2. Retrieving data from an environment variable
+### Retrieving data from an environment variable
 
 To retrieve the environment variable, simply use `$ENV_VAR_NAME` like:
 

--- a/src/content/blog/0039-rewrite-git-history.mdx
+++ b/src/content/blog/0039-rewrite-git-history.mdx
@@ -10,18 +10,18 @@ tags: [GIT]
 draft: false
 ---
 
-## 0. Motivation
+## Motivation
 
 Maintaining a clean and organized Git history is crucial for project management and collaboration.
 Over time, repositories can become cluttered with unnecessary commits, making it challenging to track changes effectively.
 In this guide, we'll walk through the process of cleaning up your Git history by rewriting commits, ensuring a streamlined and efficient version control system.
 
-## 1. Why Clean Git History Matters
+## Why Clean Git History Matters
 
 A cluttered Git history can obscure meaningful changes and make it difficult for team members to understand the evolution of a project.
 By rewriting Git history, you can eliminate unnecessary commits, squash related changes into logical units, and improve the overall clarity and readability of your repository.
 
-## 2. Step-by-Step Guide to Rewriting Git History
+## Step-by-Step Guide to Rewriting Git History
 
 > [!danger]
 > Make sure to read all post before rewriting the history.
@@ -29,14 +29,14 @@ By rewriting Git history, you can eliminate unnecessary commits, squash related 
 
 Also you might want to read <FancyLink linkText="Git Rewriting History" url="https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History"/>
 
-### 2.1. Create a New main Branch
+### Create a New main Branch
 
 To begin, create a new branch named `main` (or any preferred branch name) to perform the cleanup process without affecting the existing `master` branch.
 
 > [!warning]
 > If you already had a `main` branch, rename it to `old_main` or something similar. Adapt the code in this post so that any reference to `master` is replaced by `old_main`
 
-### 2.2. Cherry Pick the Oldest Commit on `master`
+### Cherry Pick the Oldest Commit on `master`
 
 Cherry pick the oldest commit from the `master` branch onto the new `main` branch using the following command:
 
@@ -47,7 +47,7 @@ git cherry-pick <commit_hash>
 > [!tip]
 > You might prefer using a git program such as <FancyLink linkText="Sublime Merge" url="https://www.sublimemerge.com/"/> instead.
 
-### 2.3. Edit the new `commit` date with
+### Edit the new `commit` date with
 
 Modify the date of the newly cherry-picked commit to match the original commit date using the following commands:
 
@@ -56,23 +56,23 @@ export GIT_COMMITTER_DATE="YYYY-MM-DDTHH:MM:SS"
 git commit --amend --no-edit --date="YYYY-MM-DD HH:MM:SS"
 ```
 
-### 2.4. Remove the Tag from the Cherry-Picked Commit
+### Remove the Tag from the Cherry-Picked Commit
 
 Remove the tag associated with the cherry-picked commit both locally and on GitHub to avoid conflicts with the newly created commit.
 
-### 2.5. Apply the Tag to the Newly Created Commit
+### Apply the Tag to the Newly Created Commit
 
 Apply the tag to the newly created commit on the main branch to maintain versioning consistency.
 
 
-### 2.6. Push the New Tag to GitHub
+### Push the New Tag to GitHub
 Ensure the updated tag is pushed to the remote repository on GitHub using the following command:
 
 ```bash
 git push origin <tag_name> -f
 ```
 
-## 3. Python Script for Automating the Process
+## Python Script for Automating the Process
 
 > [!danger]
 > Before running the automated process I **strongly** suggest you first try it in a demo repository.
@@ -138,6 +138,6 @@ with open("commands.sh", "w") as stream:
 
 Execute the generated shell script (`commands.sh`) to automate the Git history cleanup process.
 
-## 4. Conclusion
+## Conclusion
 
 By following these steps, you can effectively clean up your Git history and maintain a well-organized repository. Remember to review the changes carefully before pushing them to the remote repository. Embrace the power of Git's version control capabilities to enhance collaboration and project management within your development workflow.

--- a/src/content/blog/0040-prefect-essentials.mdx
+++ b/src/content/blog/0040-prefect-essentials.mdx
@@ -13,7 +13,7 @@ draft: false
 <script type="module" src="/js/posts/0040-plots-prefect.js"></script>
 import prefectDeploymentsParams from "../../images/posts/2024/0040-prefect-deployments-parameters.png";
 
-## 0. Why Prefect?
+## Why Prefect?
 
 Five years ago (in 2019), I created a pipeline to automate tasks (more info in <FancyLink linkText="Vtasks" url="https://github.com/villoro/vtasks" dark="true"/>).
 Initially, I used <FancyLink linkText="Airflow" url="https://airflow.apache.org/" company="airflow"/> (see how in <FancyLink linkText="Setting up Airflow" url="https://villoro.com/blog/setting-up-airflow/" dark="true"/>) since it was the industry standard at the time.
@@ -35,7 +35,7 @@ You might be hesitant to use a new tool without substantial support. However, Pr
 > GitHub Stars extracted using <FancyLink linkText="Daily Stars explorer" url="https://github.com/emanuelef/daily-stars-explorer"/>.
 > To quickly see the star history of a repo, you can use <FancyLink linkText="Stars History" url="https://star-history.com/"/>.
 
-## 1. Prefect Basics
+## Prefect Basics
 
 > [!tip]
 > If you want a more in-depth introduction to **Prefect** basics, you can read <FancyLink linkText="Prefect Quickstart" url="https://docs.prefect.io/latest/getting-started/quickstart/" dark="true"/> instead.
@@ -45,7 +45,7 @@ The first step is to install prefect with:
 pip install prefect
 ```
 
-### 1.1. First `flow` (aka `DAG`)
+### First `flow` (aka `DAG`)
 
 Now, you're ready to create your first `flow` (this is how `Prefect` refers to a `DAG`) using a simple decorator:
 
@@ -69,7 +69,7 @@ To run the `flow`, execute the following command:
 python main.py
 ```
 
-### 1.2. Adding `tasks` and `subflows`
+### Adding `tasks` and `subflows`
 
 In Prefect, you can add `tasks` to be run inside a `flow`.
 `Tasks` work similarly to `flows` since they are also defined with a decorator:
@@ -118,7 +118,7 @@ if __name__ == '__main__':
 > [!warning]
 > A `task` **cannot** call another `task` inside itself.
 
-### 1.3. Using `tags`
+### Using `tags`
 
 Adding `tags` in Prefect is quite straightforward:
 
@@ -134,7 +134,7 @@ with tags("env:pro", "type:greet"):
 In order to categorize, I like to use tags with `{key}:{value}` format, like `env:pro`.
 This helps me to later filter `flows`.
 
-### 1.4. Adding `logs`
+### Adding `logs`
 
 To add `logs` linked to `Prefect` you need to:
 
@@ -155,7 +155,7 @@ if __name__ == '__main__':
 
 Also, notice that in this example, I defined a `name` for the `flow`.
 
-## 2. Connection to Prefect Cloud
+## Connection to Prefect Cloud
 
 With the example we did Prefect run locally with a local database it created.
 This is useful for testing but you shouldn't be running jobs in production without a server.
@@ -179,7 +179,7 @@ prefect cloud login -k your_token
 > In some cases, you might run into problems because Prefect is still using the default settings. To clean them out, go to `~/.prefect` and delete the files that are there.
 > **Important:** this will delete the local database with the information of the flows you just ran.
 
-## 3. Using Prefect Blocks
+## Using Prefect Blocks
 
 You can use <FancyLink linkText="Prefect Blocks" url="https://docs.prefect.io/latest/concepts/blocks/" dark="true"/> to set up connections to external tools.
 For example, you can use the Slack Block to store a Slack webhook.
@@ -192,7 +192,7 @@ slack_webhook_block = SlackWebhook.load("slack") # The name of the block you jus
 slack_webhook_block.notify("Hello from Prefect!")
 ```
 
-## 4. Naming conventions
+## Naming conventions
 
 When calling flows or tasks, I like to follow a naming convention where each unit inherits a prefix from its parent.
 In the example we used before, it would be:
@@ -231,7 +231,7 @@ They in turn have different tasks inside:
   └── ...
 ```
 
-## 5. Migrating to `prefect`
+## Migrating to `prefect`
 
 I think that migrating from another orchestrator to Prefect can be easily done in incremental steps:
 
@@ -242,7 +242,7 @@ I think that migrating from another orchestrator to Prefect can be easily done i
 
 The idea behind those steps is to be able to test Prefect and see if it indeed suits your needs better compared to other solutions.
 
-### 5.1. Track executions with `prefect`
+### Track executions with `prefect`
 
 This first step towards implementing Prefect is to add some flows in any Python code you have.
 The idea is to use Prefect only for observability purposes so that you have a centralized place from where you can:
@@ -270,14 +270,14 @@ For example you could have the following flows:
 
 This is just a dummy example but it helps to illustrate how you could add better observability.
 
-### 5.2. Set up a `Prefect server`
+### Set up a `Prefect server`
 
 At this point, you will need to decide if you want to set up your Prefect server.
 If you want to do so you can read how in <FancyLink linkText="Prefect Server Setup: Configuration and Deployment" url="https://villoro.com/blog/prefect-server-setup/" dark="true"/>.
 
 You can always start creating your Prefect server and then migrate to Prefect cloud or the other way around.
 
-### 5.3. Create `deployments` for running `flows`
+### Create `deployments` for running `flows`
 
 In this step, you will create `Deployments` for the `flows` you want to be able to trigger from Prefect.
 
@@ -316,7 +316,7 @@ def sf_export(
 
 In order to see how to create the `Deployments` themselves, read <FancyLink linkText="Prefect Server Setup: Configuration and Deployment | Deployments" url="https://villoro.com/blog/prefect-server-setup#2-deployments" dark="true"/>
 
-### 5.4. Schedule `flows` with `prefect`
+### Schedule `flows` with `prefect`
 
 The last step is to finally use Prefect for scheduling the  `flows`.
 
@@ -325,7 +325,7 @@ The last step is to finally use Prefect for scheduling the  `flows`.
 
 To see how to schedule `flows`, go to <FancyLink linkText="Prefect Server Setup: Configuration and Deployment | Deployments" url="https://villoro.com/blog/prefect-server-setup#2-deployments" dark="true"/>
 
-## 6. Using `prefect.client`
+## Using `prefect.client`
 
 We can use `prefect.client` to interact with the Prefect API.
 This allows us to do very powerful things like:
@@ -339,7 +339,7 @@ That means you will need to do one of the following:
 1. Defining `async` functions whenever interact with it
 2. Calling `asyncio.run()` (or `await` if you are in a Jupyter Notebook)
 
-### 6.1. Updating `tags` at runtime
+### Updating `tags` at runtime
 
 In general `tags` are defined prior to a `flow_run`.
 However, it is possible to modify those tags at runtime.
@@ -394,7 +394,7 @@ if __name__ == '__main__':
     good_morning("pro")
 ```
 
-### 6.2. Querying `prefect` for conditional `flows`
+### Querying `prefect` for conditional `flows`
 
 You can query any `prefect` entity with the `prefect.client` like:
 
@@ -465,7 +465,7 @@ if flow_runs:
 > [!tip]
 > This is very useful when you have a pipeline that executes multiple times a day and you don't want to run a `flow`/`task` each time but only once if it hasn't been done in less than a day.
 
-### 6.3. Cancelling Stuck Flow Runs
+### Cancelling Stuck Flow Runs
 
 Occasionally, flow runs may appear as `Running` even when they are not.
 This can happen, for example, when an EMR job times out.

--- a/src/content/blog/0041-prefect-server.mdx
+++ b/src/content/blog/0041-prefect-server.mdx
@@ -10,7 +10,7 @@ tags: [Tools, Orchestration, Tutorial, Setup]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 In this post I'll explain how to:
 
@@ -20,7 +20,7 @@ In this post I'll explain how to:
 
 If you are not familiar with `Prefect` I suggest you read <FancyLink linkText="Prefect Essentials" url="https://villoro.com/blog/prefect-essentials-setup-and-migration/" dark="true"/> first.
 
-## 1. Setting up a Prefect Server
+## Setting up a Prefect Server
 
 > [!note]
 > This section is based on <FancyLink linkText="Hosting a Prefect server instance" url="https://docs.prefect.io/latest/guides/host/" dark="true"/> guide.
@@ -43,7 +43,7 @@ This basic configuration suffices for my needs, as I primarily use `prefect work
 
 Hence, a single worker adequately serves this setup.
 
-### 1.1. Creating the Prefect Server
+### Creating the Prefect Server
 
 To create the `Prefect Server`, we need a simple `docker` container with `prefect` installed.
 While there are no official images for a `docker server`, we can use the official one meant for workers.
@@ -83,7 +83,7 @@ To deploy the server somewhere, like AWS ECS running as a Service with Fargate, 
 > [!warning]
 > Ensure to **secure the server behind a VPN** to prevent unauthorized access.
 
-### 1.2. Creating a Prefect Worker
+### Creating a Prefect Worker
 
 To create a Prefect Worker, we first need to create a `Work Pool` so that the Worker we create can join it.
 
@@ -129,7 +129,7 @@ docker build --build-arg PREFECT_API_URL=XXX -f Dockerfile.worker -t northius/pr
 As before, you will need to run this docker container somewhere.
 In my case, I'll also run it as another ECS service using Fargate.
 
-## 2. Deployments
+## Deployments
 
 As the official documentation states in <FancyLink linkText="Prefect Deployments" url="https://docs.prefect.io/latest/concepts/deployments" dark="true"/>:
 
@@ -143,7 +143,7 @@ In my case, I'll use them to define:
 * From where they will get the code (a GitHub repo)
 * When the flow should be run (schedule)
 
-### 2.1. Getting the code
+### Getting the code
 
 The first thing you will need to do is to create a `Prefect Block` (more info at <FancyLink linkText="Prefect Essentials | Using prefect blocks" url="https://villoro.com/blog/prefect-essentials-setup-and-migration/#3-using-prefect-blocks" dark="true"/>) to store the `GitHub` credentials if the repo is not public.
 
@@ -168,7 +168,7 @@ pull:
 > This will only work if there is a `GitHub` block called `github` with a token that allows reading the repo.
 > This is only needed if the repo is not public.
 
-### 2.2. Creating the first Deployment
+### Creating the first Deployment
 
 Now that we've defined how to fetch the code, we will create the first `Deployment`.
 Add the following code to the `prefect.yaml` you just created.
@@ -211,7 +211,7 @@ This will deploy all `Deployments` in `prefect.yaml` to the server.
 
 Now you can head to the server and trigger a run of the `Deployment` from there.
 
-### 2.3. Advanced Usage of Deployments
+### Advanced Usage of Deployments
 
 What we've created works fine, but once you start adding multiple `Deployments`, you will probably encounter a lot of repetition.
 To avoid this, you can define some defaults that will be later used in each `Deployment` with:
@@ -261,11 +261,11 @@ With that, you can reuse the defaults like so:
 > Notice that you can overwrite the `defaults`.
 > For example here we are overwriting `tags`.
 
-### 2.4. Deploying `deployments`
+### Deploying `deployments`
 
 We've seen how to manually deploy the `Deployments`, but it's better to do it with `Continuous Deployment (CD)`.
 
-#### 2.4.1. Deploying with `Continuous Deployment (CD)`
+#### Deploying with `Continuous Deployment (CD)`
 
 Here, you will only need a `GitHub Action` (or any CD equivalent) that:
 
@@ -282,7 +282,7 @@ prefect --no-prompt deploy --all
 > You can redeploy an already existing `Deployment` without losing any data.
 > It will simply update whatever has changed.
 
-#### 2.4.2. Manual deploy
+#### Manual deploy
 
 One really cool thing you can do is to manually deploy `Deployments` when you are creating a new one.
 Here's what I do: change the `branch` reference in `prefect.yaml` to the current branch where I am developing by with:
@@ -315,7 +315,7 @@ You will only need to deploy if you change:
 * The reference `branch`
 * The flow configuration (`name`, `parameters`, `tags` etc.)
 
-## 3. Connect to Prefect Server
+## Connect to Prefect Server
 
 Now that we have a working server, we want to connect everything that runs `flows` to the server so that we can track everything.
 
@@ -328,7 +328,7 @@ PREFECT_API_URL=XXX
 > Remember, you need to replace `XXX` with the Prefect `API URL`.
 > It should be like `https//{server_url}/api`.
 
-### 3.1. Connect Docker
+### Connect Docker
 
 For anything that runs in a Docker container (such as dbt in my case), you can follow the same approach we did in the Prefect worker.
 We need to set an argument for the `API URL` and then store it as an environment variable with:
@@ -344,7 +344,7 @@ And then when we build it, we need to add the following argument:
 --build-arg PREFECT_API_URL=XXX
 ```
 
-### 3.2. Connect EMR
+### Connect EMR
 
 In `EMR`, we need to set the environment variable at the `driver`.
 We can do that by adding the following configuration:
@@ -355,7 +355,7 @@ We can do that by adding the following configuration:
 > [!warning]
 > This is for EMR serverless but is very similar for the non-serverless EMR.
 
-## 4. Handling Multiple Environments
+## Handling Multiple Environments
 
 You probably have multiple environments such as `pre`, `pro`, and maybe also `sandbox`.
 
@@ -368,11 +368,11 @@ With a dedicated server, you will have better isolation but it would be more wor
 In my case, I wanted simplicity and lower costs so **I went with a central server**.
 In that case, the only important bit is you will need to pass to each flow the `env` variable as a `parameter`, and then you will need some code to assume different roles per environment.
 
-## 5. Useful Code Snippets
+## Useful Code Snippets
 
 Here you have some snippets that can help you get started.
 
-### 5.1. Updating Tags Dynamically
+### Updating Tags Dynamically
 
 One really cool thing you can do with Prefect is to dynamically edit the tags of each flow at runtime.
 In my case, it's very useful for tagging the environment where the flow is running (such as `env:pro` or `env:pre`).
@@ -410,7 +410,7 @@ def update_tags(tags):
 > This example **only** works when called from a flow.
 > If you want to run it from a task, you will need to fetch the task instead.
 
-### 5.2. Running a Lambda
+### Running a Lambda
 
 Here you have the simplest example I have for running external jobs from Prefect.
 This calls any lambda you might want:
@@ -450,7 +450,7 @@ def run_lambda(env, name):
     _run_lambda(client, name)
 ```
 
-### 5.3. Defining a Flow for Each Possible Lambda
+### Defining a Flow for Each Possible Lambda
 
 With the `base.py` code for running lambdas, you can define a flow for each lambda you have.
 As an example, we could have:

--- a/src/content/blog/0042-emr.mdx
+++ b/src/content/blog/0042-emr.mdx
@@ -13,7 +13,7 @@ tags: [AWS, Tutorial]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 Tired of wrestling with complex setups when trying to get PySpark up and running on EMR? You're not alone!
 This guide was created out of frustration with overly convoluted configurations.
@@ -25,7 +25,7 @@ Whether you're new to PySpark or just tired of the headache, I've got your back.
 > This post breaks down multiple concepts step by step.
 > If you prefer to see the final result, head to the last section where you can find everything consolidated.
 
-## 1. Running a script in EMR
+## Running a script in EMR
 
 The simplest way to execute PySpark code on EMR is by storing a Python file in S3.
 For example, let's suppose we have a `main.py` file in a bucket named `your-bucket`:
@@ -60,11 +60,11 @@ Next, you submit a job using the specified file (`s3://your-bucket/main.py`) as 
 A common solution is to create a Python package so you can import code from other files. Let's explore how to do this next.
 
 
-## 2. Using packages
+## Using packages
 
 In general, you'll need to use two different types of packages: `Java` packages and `Python` packages.
 
-### 2.1 Java packages
+### Java packages
 
 Adding Java packages is quite straightforward:
 
@@ -78,7 +78,7 @@ Adding Java packages is quite straightforward:
 
 With that, you should be able to use that package.
 
-### 2.2. Python packages
+### Python packages
 
 The simplest way of adding a Python package is by <FancyLink linkText="Setting up a bootstrap action" url="https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-bootstrap.html" company="aws"/> (as recommended in <FancyLink linkText="QA: EMR install python libraries" url="https://repost.aws/knowledge-center/emr-install-python-libraries" company="aws"/>)
 
@@ -86,13 +86,13 @@ The main problem with that is that you'll be downloading the package at runtime.
 
 The way to overcome those problems is to **create a docker image**.
 
-## 3. Creating an environment with Docker
+## Creating an environment with Docker
 
 According to <FancyLink linkText="EMR spark docker" url="https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-spark-docker.html" company="aws"/> by AWS, you can create a Docker image and later use it to run EMR. However, I think it's better to create a virtual environment using Docker and export it as a `tar.gz` file.
 
 With that, you can simply export the file to S3 and later use it.
 
-### 3.1. Add external packages
+### Add external packages
 
 The overall idea is to follow <FancyLink linkText="EMR serverless samples" url="https://github.com/aws-samples/emr-serverless-samples/tree/main/examples/pyspark/dependencies" dark="true"/>.
 In this example I'm using <FancyLink linkText="Poetry python package manager" url="https://villoro.com/blog/poetry-python-package-manager" dark="true"/> since I think it's better than regular `pip`.
@@ -159,7 +159,7 @@ Then you can set up an `EMR` cluster to use that environment with:
 > [!warning]
 > Make sure to adapt the path (`s3:/your-bucket/venv/my_package-latest.tar.gz` in the example) to the file you created.
 
-### 3.2. Create a 'Package' for Adding Code
+### Create a 'Package' for Adding Code
 
 Now that we know how to add external packages, we can reuse it to also be able to import our own code.
 As stated in  <FancyLink linkText="How to run a Python project (package) on AWS EMR serverless?" url="https://stackoverflow.com/questions/74193417/how-to-run-a-python-project-package-on-aws-emr-serverless"/>, the idea is to create a Python package and then install it.
@@ -224,7 +224,7 @@ And it is compiled with:
 docker build --output . . --build-arg PACKAGE_VERSION=2.1.7 # Any version you want
 ```
 
-### 3.3. Export the environment with CD
+### Export the environment with CD
 
 Here, the idea is to have a GitHub action that uploads the virtual environment whenever there is a commit to `main`.
 
@@ -238,7 +238,7 @@ One thing that I find very useful is to always export the real version, such as 
 
 You might want to read <FancyLink linkText="Managing package versions with Poetry" url="https://villoro.com/blog/managing-package-versions-with-poetry" dark="true"/> for more information about how to manage versions with Poetry.
 
-## 4. Generic entrypoint
+## Generic entrypoint
 
 You've seen how to add external packages and how to install your own code as a package. However, you still need an entrypoint for running EMR jobs.
 
@@ -292,14 +292,14 @@ module.main()
 > [!note]
 > This does exactly the same as before.
 
-## 5. Handling Parameters
+## Handling Parameters
 
 Now that you have a unique entrypoint, you could use `sys.argv` or `argparse` to catch the entrypoint from the arguments, as explained in <FancyLink linkText="How do I access command line arguments?" url="https://stackoverflow.com/questions/4033723/how-do-i-access-command-line-arguments"/>.
 One way of doing that would be to always use the first parameter for the entrypoint and the rest of the parameters as the actual script parameters.
 
 But there is a better way with `click`.
 
-### 5.1. Catching Generic Parameters with `click`
+### Catching Generic Parameters with `click`
 
 The idea here is to define the entrypoint as a parameter in `click` and then catch the rest of the parameters as explained in <FancyLink linkText="Add unspecified options to cli command using python-click" url="https://stackoverflow.com/a/32946412/3488853"/>.
 
@@ -362,7 +362,7 @@ def main(name, num):
 > [!warning]
 > Notice that all parameters are as `strings`.
 
-### 5.2. Define Script Parameters with `pydantic`
+### Define Script Parameters with `pydantic`
 
 One way to improve the previous code is to define the parameters with <FancyLink linkText="Pydantic" url="https://docs.pydantic.dev/"/>. This way you don't need to handle the castings and can use the powerful validators from pydantic.
 
@@ -384,14 +384,14 @@ def main(**kwargs):
     print(f"Hello {args.name} with {args.num=}")
 ```
 
-## 6. Track Executions with Prefect
+## Track Executions with Prefect
 
 One really good way of having better observability on EMR jobs is to add Prefect.
 If you are not familiar with Prefect I suggest you read <FancyLink linkText="Prefect Essentials" url="https://villoro.com/blog/prefect-essentials-setup-and-migration/" dark="true"/> first.
 
 Also make sure you connect EMR to Prefect by following <FancyLink linkText="Connect EMR | Setting Up and Deploying Prefect Server" url="https://villoro.com/blog/prefect-server-setup-configuration-deployment#32-connect-emr" dark="true"/>.
 
-### 6.1. Jobs as Flows
+### Jobs as Flows
 
 The idea here is to create a flow at the entrypoint so that you can see each run.
 The idea is to create a flow dynamically with  `flow(name="flow_name")(function)(*args, **kwargs)`.
@@ -410,7 +410,7 @@ def main(ctx, entrypoint):
     flow(name=entrypoint)(module.main)(**kwargs)
 ```
 
-### 6.2. Adding Tasks and/or Subflows
+### Adding Tasks and/or Subflows
 
 You can follow the same approach to add different tasks and/or subflows.
 For example, let's imagine you are extracting multiple tables from somewhere. Here you could create a Prefect task for each table.
@@ -425,12 +425,12 @@ for table in tables:
     task(name=name)(process_one_table)(name=table.name, **any_other_arguments)
 ```
 
-## 7. Putting it All Together
+## Putting it All Together
 
 We have seen multiple code snippets explaining the different parts.
 Here, I'm adding the final code so that it's easier to see the final outcome.
 
-### 7.1. Entrypoint
+### Entrypoint
 
 This takes care of:
 
@@ -506,7 +506,7 @@ if __name__ == "__main__":
     main()
 ```
 
-### 7.2. Arguments code
+### Arguments code
 
 Here we define:
 * `BaseParams`  to be extended in each module
@@ -578,7 +578,7 @@ def catch_params(ParamsClass):
     return decorator
 ```
 
-### 7.3. Sample module
+### Sample module
 
 Here is an example of how to define a job:
 

--- a/src/content/blog/0043-self-healing-pipelines.mdx
+++ b/src/content/blog/0043-self-healing-pipelines.mdx
@@ -10,13 +10,13 @@ tags: [DE, Best Practices]
 draft: false
 ---
 
-## 0. Motivation
+## Motivation
 
 In traditional pipelines, data processing typically focuses on the last batch, such as yesterday's data for daily executions.
 While effective under normal circumstances, multiple failures can lead to tedious backfilling processes.
 This post delves into the concept of self-healing pipelines, which streamline operations by automatically backfilling failed executions, reducing the need for manual interventions.
 
-## 1. Regular batch processing
+## Regular batch processing
 
 Let's imagine you have a daily pipeline that was running well until Friday (`2024-05-03`) when someone pushed a bug to production. 
 You discover the mistake on Monday (`2024-05-06`) morning.
@@ -30,7 +30,7 @@ However, this approach has some limitations:
 1. **Manual Intervention**: Backfilling requires manual intervention to schedule the jobs, which can be time-consuming and prone to errors.
 2. **Cost Considerations**: Running three separate jobs for each day can be less cost-effective, especially in systems like Spark, where spinning up multiple jobs incurs additional overhead.
 
-## 2. Processing new data
+## Processing new data
 
 The concept of `Self-healing pipelines`  revolves around processing data that is newer than the last successful extraction performed.
 In essence, the pipeline automatically identifies and handles data gaps or discrepancies by processing only the most recent data.
@@ -49,7 +49,7 @@ In the scenario described earlier, where the last correct extraction was perform
 > **Important:** When processing a large number of days, it may be necessary to allocate additional resources.
 > Moreover, automatic scaling of resources might be required for seamless operation.
 
-### 2.1. Partitioning
+### Partitioning
 
 Partitioning the data lake into three layers, as recommended by Databricks in their <FancyLink linkText="Medallion Architecture" url="https://www.databricks.com/glossary/medallion-architecture"/>, provides a structured approach to data management.
 Here are the layers:
@@ -60,14 +60,14 @@ Here are the layers:
 
 ![Data Lake Layers](../../images/posts/2024/0043-data-lake-layers.jpg)
 
-#### 2.1.1. Partitions in `bronze`
+#### Partitions in `bronze`
 
 Partitioning the `bronze` layer by the extraction datetime, typically labeled as `p_extracted_at`, offers several advantages:
 
 * **Avoidance of rewriting old partitions**: New data extractions can be appended without the need to update or rewrite existing partitions. This simplifies data ingestion and reduces the risk of inadvertently modifying historical data.
 * **Facilitation of tracking**: The partition column provides clear visibility into when the last extraction occurred and identifies which data needs processing. This makes it easier to monitor data freshness and manage incremental processing workflows effectively.
 
-#### 2.1.2. Partitions on `silver`/`gold`
+#### Partitions on `silver`/`gold`
 
 Then on `silver` and/or `gold` layers you can switch to partition by `creation_date` (based on the data) or to not partition at all.
 As a reference see <FancyLink linkText="When to partition tables on Databricks" url="https://docs.databricks.com/en/tables/partitions.html"/>.
@@ -76,7 +76,7 @@ They suggest that you only partition big tables (> 1TB) when using `delta` table
 So on those layers you will need to read all new partitions from `bronze` and update that table on `silver`/`gold`.
 The easiest way is to use the `MERGE INTO` option that both <FancyLink linkText="Delta Lake" url="https://delta.io/"/> and <FancyLink linkText="Iceberg" url="https://iceberg.apache.org/" company="iceberg"/> support.
 
-### 2.2. Deduplication
+### Deduplication
 
 In the `bronze` layer, where data extraction occurs, partitioning by `p_extracted_at` is essential for efficient data management. However, this partitioning strategy can lead to duplicates when processing multiple `bronze` partitions. To address this issue, we implement deduplication by retaining only the latest entry for each unique identifier (`id`).
 
@@ -89,7 +89,7 @@ Here's an overview of the deduplication process:
 1. **Identify unique rows**: Use the `row_number()` function to assign a sequential number (`rn`) to each row within a partition, ordered by the `last_modified_at` field (or `p_extracted_at` if `last_modified_at` is unavailable). This function is applied in descending order, ensuring that the latest entry for each `id` receives `rn = 1`.
 2. **Filter duplicates**: Keep only the records where `rn = 1`, as they represent the latest version of each unique identifier. Discard any rows with `rn > 1`, as they are duplicates.
 
-#### 2.2.1. Deduplication when there is no `id` column
+#### Deduplication when there is no `id` column
 
 If there is no `id` column, you will need to create one.
 This is done by creating a `composite key` as described in <FancyLink linkText="dbt | Composite key" url="https://docs.getdbt.com/reference/resource-configs/unique_key#use-a-combination-of-two-columns-as-a-unique-key"/>.
@@ -100,11 +100,11 @@ This is done by creating a `composite key` as described in <FancyLink linkText="
 
 That can easily be replicated in `python` or other programming languages.
 
-## 3. Code snippets
+## Code snippets
 
 Now that we have all the concepts clear, let's see how to implement it in `python` and `SQL`.
 
-### 3.1. Python
+### Python
 
 I use `spark` with `python` for extracting data for new sources.
 The important part here is to:
@@ -113,7 +113,7 @@ The important part here is to:
 2. Extract new data based on `max_datetime`
 3. Export it partitioned by `p_extracted_at`
 
-#### 3.1.1. Get `max_datetime`
+#### Get `max_datetime`
 
 ```python
 from datetime import datetime
@@ -186,7 +186,7 @@ def infer_max_datetime(
 > Given that the pipeline can fail and/or that we can do backfills, that max value might not be in the latest partition.
 > This is why I recommend querying `N` days of data (7 by default) and getting the max from there.
 
-#### 3.1.2. Extract new data and store it
+#### Extract new data and store it
 
 ```python
 from datetime import datetime
@@ -222,7 +222,7 @@ if __name__ == '__main__':
 > `get_data`  is not defined since it's out of scope.
 > It's just a function that queries some external system.
 
-### 3.2. dbt (SQL)
+### dbt (SQL)
 
 I use `dbt` for transforming and creating the `silver` and `gold` layers.
 Those examples should explain how to:
@@ -230,7 +230,7 @@ Those examples should explain how to:
 * Process only new data
 * Deduplicate
 
-#### 3.2.1. dbt macros
+#### dbt macros
 
 With `dbt`, I like to define 2 macros:
 
@@ -290,7 +290,7 @@ macros:
         description: Name of the column that contains the `last_update`
 ```
 
-#### 3.2.2. dbt model
+#### dbt model
 
 Once you have the macros, the basic code for the model would look like:
 
@@ -333,7 +333,7 @@ FROM deduplicated
 > In general, it should be `materialization=incremental` (see: <FancyLink linkText="dbt | Incremental models" url="https://docs.getdbt.com/docs/build/incremental-models"/>).
 > And you might also need to set up the incremental strategy. For example, with <FancyLink linkText="dbt Athena" url="https://github.com/dbt-athena/dbt-athena"/> I set the `incremental_strategy: merge` and the `table_type: iceberg`.
 
-## 4. Handling schema changes
+## Handling schema changes
 
 One last thing you might want to automatically handle are schema changes.
 You cannot handle all of them but you can easily adapt to:
@@ -348,7 +348,7 @@ You cannot handle all of them but you can easily adapt to:
 > [!warning]
 > Notice that if you implement some automatic handling of schema changes you might have inconsistent data that you will need to handle. Do it at your own risk.
 
-### 4.1. New or missing columns
+### New or missing columns
 
 If you want to automatically handle missing columns, you simply need to add them as `NULL` in the input dataframe.
 
@@ -406,7 +406,7 @@ def fix_missmatching_columns(spark, sdf, tablename):
     return sdf
 ```
 
-### 4.2. Handling type changes
+### Handling type changes
 
 If you experience multiple type changes in your tables and you want to automatically handle them, I think that the best thing you can do is to convert all columns to `string`.
 Then on the `silver` layer, you can apply the proper `type` you want by casting.

--- a/src/content/blog/0044-running-dbt.mdx
+++ b/src/content/blog/0044-running-dbt.mdx
@@ -10,7 +10,7 @@ tags: [SQL, DE, AWS, Setup, Tutorial, dbt]
 draft: false
 ---
 
-## 0. Motivation
+## Motivation
 
 <FancyLink linkText="dbt" url="https://www.getdbt.com/"/> serves as a gateway for SQL practitioners to engage more deeply in data engineering tasks.
 While dbt Cloud offers a managed solution, budget constraints may lead to exploring self-hosting options.
@@ -24,7 +24,7 @@ When setting this up, I got a lot of information and direction from these posts:
 
 However, I still think I have multiple improvements to share, such as handling it with `poetry`, integrating with `prefect`, exporting dbt run results, among other things. This is why I'm documenting everything.
 
-## 1. The components
+## The components
 
 In our setup, we combine `dbt`, `Docker`, and `AWS ECS (Fargate)` to streamline the execution of data transformation pipelines:
 
@@ -46,7 +46,7 @@ Here you can see a diagram of the overall architecture:
 
 ![Backfill missing data](../../images/posts/2024/0044-dbt-architecture.jpg)
 
-## 2. Handling packages in docker
+## Handling packages in docker
 
 From the beginning, I wanted to have a simple Docker image that is independent of the dbt code.
 This way, changes to dbt itself won't require creating a new image and uploading it to ECR.
@@ -61,7 +61,7 @@ To decide which version to download and use, I export the `pyproject.toml`, whic
 
 You can read more about it in <FancyLink linkText="Deploying and Running dbt on AWS Fargate" url="https://medium.com/hashmapinc/deploying-and-running-dbt-on-aws-fargate-872db84065e4" dark="true"/> (section `Docker Image`).
 
-## 3. Docker images
+## Docker images
 
 With this approach, we have three Docker images:
 
@@ -72,7 +72,7 @@ With this approach, we have three Docker images:
 How to upload these images to ECR is out of scope.
 For guidance, refer to <FancyLink linkText="How to Build and Push Docker Images to AWS ECR" url="https://www.freecodecamp.org/news/build-and-push-docker-images-to-aws-ecr/"/>
 
-### 3.1. Docker.base
+### Docker.base
 
 This base Docker image installs Python and some basic Python packages.
 
@@ -121,7 +121,7 @@ RUN python -m pip install --upgrade \
   --no-cache-dir
 ```
 
-### 3.2. Docker.venv
+### Docker.venv
 
 This image creates a virtual environment with all dependencies.
 It also packages all dbt code. Finally, it exports both as a `.tar.gz` file.
@@ -161,7 +161,7 @@ COPY --from=base /usr/app/dbt/dist/*.tar.gz /dist/
 > [!note]
 > The `dbt_src` is the folder that contains the actual `dbt` code. That includes `dbt_project.yml`, `models`, `tests`, `macros` folders, etc.
 
-### 3.3. Docker.ecs
+### Docker.ecs
 
 This image runs in `Fargate`.
 Here, I set up the connection to `prefect` (more info at <FancyLink linkText="Connect Docker | Setting Up and Deploying Prefect Server" url="https://villoro.com/blog/prefect-server-setup-configuration-deployment#31-connect-docker/" dark="true"/>).
@@ -188,12 +188,12 @@ COPY scripts .
 ENTRYPOINT ["/bin/bash", "./setup_and_run_dbt.sh"]
 ```
 
-## 4. Continuous Delivery (CD)
+## Continuous Delivery (CD)
 
 As mentioned before, there are two `tar.gz` files: one with the virtual environment (`venv`) and another with the code (`dist`).
 The goal of `CD` is to create both and upload them to S3, along with the `pyproject.toml` and `profiles.yml` files.
 
-### 4.1. CD Pacakges github action
+### CD Pacakges github action
 
 ```yaml
 name: CD Packages
@@ -248,7 +248,7 @@ jobs:
 > [!warning]
 > You need to set the `role ARN` (replace `xxx` in the code) needed for uploading the files to S3.
 
-### 4.2. `upload_all.py` script
+### `upload_all.py` script
 
 There are multiple ways the documents can be uploaded.
 Since I'm proficient with python I'm using it, but you can use any alternative approach following a similar process.
@@ -313,7 +313,7 @@ if __name__ == "__main__":
 > I use the `pyproject.toml` file to store a lot of configuration such as `S3` paths.
 > I haven't included a snippet since most data is private, but it should be easy to infer.
 
-## 5. Scripts
+## Scripts
 
 During runtime, we need to download all files created during the CD process.
 This is done with the following three scripts:
@@ -322,7 +322,7 @@ This is done with the following three scripts:
 * `scripts/download_code.py`
 * `scripts/setup_and_run_dbt.sh`
 
-### 5.1. Download poetry config
+### Download poetry config
 
 This script:
 
@@ -395,7 +395,7 @@ if __name__ == "__main__":
     download_all()
 ```
 
-### 5.2. Download code
+### Download code
 
 This script:
 
@@ -503,7 +503,7 @@ if __name__ == "__main__":
     main()
 ```
 
-### 5.3. Setup and run dbt
+### Setup and run dbt
 
 This script:
 
@@ -531,7 +531,7 @@ poetry run python run.py "$@"
 > [!note]
 > The `"$@"` is used to pass all arguments from the Docker container to the `run.py` script.
 
-## 6. Running dbt
+## Running dbt
 
 While running dbt as a CLI is an option, it limits our ability to:
 
@@ -550,12 +550,12 @@ args = ["build", "--select", "tag:my_tag"]
 dbtRunner().invoke(args)
 ```
 
-## 7. Integrating with Prefect
+## Integrating with Prefect
 
 > [!note]
 > Remember that you need to connect to Prefect. For more information, visit <FancyLink linkText="Connect Docker | Setting Up and Deploying Prefect Server" url="https://villoro.com/blog/prefect-server-setup-configuration-deployment#31-connect-docker/" dark="true"/>
 
-### 7.1. Tasks
+### Tasks
 
 For better observability, I recommend defining each dbt command as a Prefect task. This involves adding the `@task` decorator, like so:
 
@@ -580,7 +580,7 @@ if __name__ == '__main__':
     run()
 ```
 
-### 7.2. Adding logs
+### Adding logs
 
 A valuable feature of dbt is the ability to register callbacks (<FancyLink linkText="Registering callbacks | Programmatic invocations" url="https://docs.getdbt.com/reference/programmatic-invocations#registering-callbacks"/>).
 With callbacks, you can easily add custom logs, particularly handy for sending logs from dbt to Prefect. To achieve this, you need to:
@@ -588,7 +588,7 @@ With callbacks, you can easily add custom logs, particularly handy for sending l
 1. Create a callback function to handle the logs.
 2. Set up the logger. However, this isn't straightforward as it needs to be tied to a Prefect task.
 
-#### 7.2.1. Create a `callback`
+#### Create a `callback`
 
 The concept here involves capturing information from the dbt events and sending the log based on the severity level.
 
@@ -652,7 +652,7 @@ EVENTS_TO_LOG = [
 ]
 ```
 
-#### 7.2.2. Set up the logger
+#### Set up the logger
 
 To set up the logger, you need to declare a **global** `logger` in a function that is called inside a prefect `task` or `flow`.
 
@@ -677,14 +677,14 @@ def run_dbt_command(args):
 > [!warning]
 > Do not forget to add the `log_callback` to the `dbtRunner`.
 
-## 8. Exporting data
+## Exporting data
 
 There are two things you might want to export:
 
 1. <FancyLink linkText="dbt docs" url="https://docs.getdbt.com/reference/resource-configs/docs"/> 
 2. <FancyLink linkText="dbt run results" url="https://docs.getdbt.com/reference/artifacts/run-results-json"/> 
 
-### 8.1. Docs
+### Docs
 
 The idea here is to combine the following files into one:
 
@@ -739,7 +739,7 @@ def merge_docs():
 > [!tip]
 > Once exported, you simply need to upload the `docs` file into `S3`.
 
-### 8.2. dbt run results
+### dbt run results
 
 The idea is to extract information about the `runs` and `run_results` from the `target/run_results.json` file.
 This is done with some `pandas` code and then exported to `glue` with `awswrangler`.
@@ -833,7 +833,7 @@ def export_execution_and_run_results():
     export_run_results(data)
 ```
 
-## 9. `run.py` complete scripts
+## `run.py` complete scripts
 
 We've seen parts of the `run.py`, but I think it's useful to see the complete code.
 The only missing part to describe is that I use <FancyLink linkText="click" url="https://github.com/pallets/click" dark="true"/>.

--- a/src/content/blog/0045-dbt-testing.mdx
+++ b/src/content/blog/0045-dbt-testing.mdx
@@ -10,7 +10,7 @@ tags: [SQL, DE, Best Practices, dbt]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 In our previous post, we discussed how to self-host dbt on AWS ECS (Fargate) for cost-effective scalability and better control over data transformation processes.
 If you haven't read that post, see <FancyLink linkText="Running dbt with AWS ECS (Fargate)" url="https://villoro.com/blog/running-dbt-with-aws-ecs-fargate/" dark="true"/>.
@@ -20,12 +20,12 @@ This time, we'll take it a step further by diving into testing dbt projects with
 By integrating SQL linting, smoke testing, and automation, we can maintain high-quality dbt projects.
 This guide will cover setting up a SQL linter with Sqlfluff, automating testing with pre-commit hooks, and creating a streamlined continuous integration (CI) pipeline.
 
-## 1. SQL Linter
+## SQL Linter
 
 The idea is to have a SQL linter that helps get well-formatted SQL code with a unified style inside the repo.
 As the linter, I recommend using <FancyLink linkText="Sqlfluff" url="https://github.com/sqlfluff/sqlfluff" dark="true"/>.
 
-### 1.1. Integrating it with dbt
+### Integrating it with dbt
 
 To correctly parse dbt code (especially the templating part), we need to set it up properly.
 The easiest way is to create the `.sqlfluff` file in the repo root as follows:
@@ -74,7 +74,7 @@ dbt_src:
 
 If needed, you can exclude some paths using the `.sqlfluffignore` file as mentioned in <FancyLink linkText="Sqlfluff Configuration" url="https://docs.sqlfluff.com/en/stable/configuration.html#installation-configuration" company="readthedocs"/>
 
-### 1.2. Automatic testing with pre-commit
+### Automatic testing with pre-commit
 
 With pre-commit, you can run the linter before each commit.
 More info about it in <FancyLink linkText="pre-commit" url="https://villoro.com/blog/pre-commit/" dark="true"/>.
@@ -117,7 +117,7 @@ Here we are using 2 jobs:
 > If you want to make it faster, you can keep only one of the 2 jobs.
 > I prefer having both the fixing capabilities and better failure information.
 
-## 2. Smoke testing with DuckDB
+## Smoke testing with DuckDB
 
 The testing strategy I've seen in most dbt projects is to rely on users to manually run dbt to validate that the code works.
 This is problematic since users might not run those tests (especially first-time contributors).
@@ -126,7 +126,7 @@ To have some guarantees over the dbt code, we can do **smoke testing** using <Fa
 The idea is to have some testing data (it can either be anonymized prod data or synthetic data) so that we can run dbt using <FancyLink linkText="dbt-duckdb" url="https://github.com/duckdb/dbt-duckdb" dark="true"/>.
 This can be automated to run at every pull request, ensuring some guarantees about the code.
 
-## 3. Testing data
+## Testing data
 
 The idea is to have some files that define each table and to have a script that exports all of that into a duckdb file that can be used for dbt.
 
@@ -146,7 +146,7 @@ It should be something like:
   └── ...
 ```
 
-### 3.1. Export CSVs
+### Export CSVs
 
 The simplest way of exporting data into duckdb is by a CSV file.
 
@@ -160,7 +160,7 @@ FROM read_csv('{path}/{table}.csv', header=True)
 
 See <FancyLink linkText="CSV - DuckDB" url="https://duckdb.org/docs/data/csv/overview" dark="true"/> for more information about `read_csv`.
 
-### 3.2. Manual SQLs
+### Manual SQLs
 
 There are some cases where the `read_csv` doesn't work as expected.
 This has happened to me mostly when I have non-primitive types such as `MAP`, `STRUCT`, and/or `JSON` in one column.
@@ -245,7 +245,7 @@ INSERT INTO bronze__metadata.emr_history VALUES (
 > [!note]
 > In this example, you can see how to create most types such as `STRUCT`, `MAP`, and `ARRAYS`.
 
-### 3.3. Generate testing data script
+### Generate testing data script
 
 To export all that data, I use a script that:
 
@@ -393,7 +393,7 @@ if __name__ == "__main__":
     main()
 ```
 
-## 4. Running dbt-duckdb
+## Running dbt-duckdb
 
 To do the smoke test, you can run dbt the same way you run it in production.
 That could be `dbt build --select xx --exclude yy` or using a Python script as described in <FancyLink linkText="Running dbt with AWS ECS (Fargate)" url="https://villoro.com/blog/running-dbt-with-aws-ecs-fargate/" dark="true"/>.
@@ -401,7 +401,7 @@ That could be `dbt build --select xx --exclude yy` or using a Python script as d
 There might be some models or tests that you don't want to test during CI (such as testing data freshness).
 To handle that, I use the `no_test` tag and pass `--exclude tag:no_test` when running dbt.
 
-### 4.1. In memory vs working with a file
+### In memory vs working with a file
 
 <FancyLink linkText="dbt-duckdb" url="https://github.com/duckdb/dbt-duckdb" dark="true"/> can run in 2 ways:
 
@@ -439,7 +439,7 @@ dbt_northius:
 > [!note]
 > The naming for `awsdatacatalog.duckdb` is for compatibility with Athena, more on that in the next section.
 
-### 4.3. Duckdb filename
+### Duckdb filename
 
 You might wonder why the duckdb file is called `awsdatacatalog.duckdb`, and behind that name, there is a very interesting trick.
 In production, I'm using Athena (see <FancyLink linkText="Running dbt with AWS ECS (Fargate)" url="https://villoro.com/blog/running-dbt-with-aws-ecs-fargate/" dark="true"/>) and there the default catalog is called `awsdatacatalog`.
@@ -472,7 +472,7 @@ With duckdb, that implies that `source(xx)` will be read from the `awsdatacatalo
 > [!tip]
 > Running duckdb in memory is **~8x faster** based on my current project with around 1000 models.
 
-## 5. Continuous Integration (CI)
+## Continuous Integration (CI)
 
 Once you are able to run dbt locally with DuckDB, you can set up the Continuous Integration (CI) job.
 With that, it will run at each commit done in a pull request.
@@ -524,7 +524,7 @@ jobs:
 > [!tip]
 > Remember to set this test as a mandatory prerequisite for merging PRs into the `main` branch.
 
-## 6. Integrating with other SQL engines
+## Integrating with other SQL engines
 
 You probably will use another engine in production instead of duckdb.
 In my case, I use <FancyLink linkText="dbt-athena" url="https://github.com/dbt-athena/dbt-athena" dark="true"/>.
@@ -579,7 +579,7 @@ Then you can simply call it with:
   - "{{ optimize() }}"
 ```
 
-## 7. Conclusion
+## Conclusion
 
 Testing is a critical part of any data engineering workflow, and integrating dbt with DuckDB for testing can significantly enhance the reliability of your data transformation processes.
 By setting up SQL linting, automating tests with pre-commit hooks, and establishing a CI pipeline, you can ensure that your dbt models are robust and error-free.

--- a/src/content/blog/0046-salesforce.mdx
+++ b/src/content/blog/0046-salesforce.mdx
@@ -12,7 +12,7 @@ draft: false
 
 <script type="module" src="/js/posts/0046-plots-salesforce.js"></script>
 
-## 0. Motivation
+## Motivation
 
 I've spent a lot of time figuring out how to get data from Salesforce using Python.
 Along the way, I faced many challenges and learned a lot.
@@ -21,7 +21,7 @@ This post is a guide to extracting data from Salesforce with Python.
 I'll explain things step by step, give examples, and offer tips to make it easier for you.
 My goal is to help you get the data you need from Salesforce for your own projects.
 
-## 1. Simple Salesforce
+## Simple Salesforce
 
 There are multiple ways of querying Salesforce data with Python.
 I prefer using <FancyLink linkText="Simple Salesforce" url="https://github.com/simple-salesforce/simple-salesforce" dark="true"/> because, as the name suggests, it simplifies the data extraction process.
@@ -44,7 +44,7 @@ sf = Salesforce(
 > [!warning]
 > Please ensure that you replace all the placeholder strings with the appropriate values.
 
-### 1.1. Querying and `__getattr__`
+### Querying and `__getattr__`
 
 This is the simplest query you can execute:
 
@@ -65,7 +65,7 @@ sf.__getattr__("Account").get('003e0000003GuNXAA0')
 > [!tip]
 > You'll find that this approach can be applied throughout this post.
 
-## 2. Querying options
+## Querying options
 
 There are various methods available for retrieving data from Salesforce using the <FancyLink linkText="Simple Salesforce" url="https://github.com/simple-salesforce/simple-salesforce" dark="true"/> library.
 Here's a detailed overview of each:
@@ -89,7 +89,7 @@ You can also view the query time of each method using the same query.
 > [!tip]
 > I would recommend using either `query_all_iter`.
 
-### 2.1. Entity get
+### Entity get
 
 You can use the `get` method to retrieve a single entity:
 
@@ -100,7 +100,7 @@ sf.Account.get('003e0000003GuNXAA0')
 > [!warning]
 > While useful for retrieving a single value, it's not suitable for exporting a large number of rows.
 
-### 2.2. query
+### query
 
 You can use `sf.query` to retrieve multiple rows at once.
 However, there's a limit on the number of records you can fetch. If your query exceeds this limit, you'll need to use `sf.query_more`.
@@ -119,7 +119,7 @@ You can find more information about this in the <FancyLink linkText="Queries | S
 > [!warning]
 > I don't suggest using this option since there are easier methods available that don't require dealing with the `sf.query_more` option.
 
-### 2.3. query_all
+### query_all
 
 This method is similar to `query`, but it returns all results as a Python object:
 
@@ -130,7 +130,7 @@ sf.query_all("SELECT Id, Name FROM Account")
 > [!warning]
 > The problem with this approach is that you can easily encounter `Out of Memory (OOM)` errors when attempting to load a large amount of data into memory.
 
-### 2.4. query_all_iter
+### query_all_iter
 
 This works similarly to the previous methods, but the result is an iterator.
 This allows you to process each row one at a time and avoid `Out of Memory (OOM)` errors.
@@ -151,7 +151,7 @@ You may notice that the first row takes longer to retrieve than the rest when qu
 > [!tip]
 > This is the method I recommend using.
 
-### 2.5. Bulk
+### Bulk
 
 There are two ways of querying with `bulk`: the regular one and the lazy operation.
 The regular method works similarly to `query_all_iter`, allowing you to iterate over the results without encountering OOM errors.
@@ -189,7 +189,7 @@ for chunk in data:
 > This function is consistently **2 to 3 times faster** than `query_all_iter`.
 > However, since it cannot extract compound fields, it would make extraction more complex, as you would need to recreate all that logic in the data lake.
 
-### 2.6. Bulk2
+### Bulk2
 
 Finally, there's also the `bulk2` option.
 
@@ -214,7 +214,7 @@ However, one important caveat is that the result is a Python string similar to a
 During testing, I observed around a 20% performance improvement compared to `bulk`.
 However, given that it's not a significant improvement, I believe it's not worth the effort.
 
-## 3. Avoiding Timeouts and Out of Memory Errors
+## Avoiding Timeouts and Out of Memory Errors
 
 After extracting data from Salesforce for several months, I've discovered a couple of tricks to make the pipeline more resilient. These include:
 
@@ -224,7 +224,7 @@ After extracting data from Salesforce for several months, I've discovered a coup
 Additionally, I've found it beneficial to always query only the data that has been updated.
 You can find more information about this approach in <FancyLink linkText="Self-Healing Pipelines" url="https://villoro.com/blog/self-healing-pipelines/" dark="True"/>.
 
-### 3.1. Chunks
+### Chunks
 
 Exporting data in chunks is a straightforward method. For tables that may contain a large amount of data, I prefer exporting records in smaller, manageable chunks.
 The chunk size can be adjusted based on query speed observations.
@@ -277,7 +277,7 @@ This approach helps to:
 * Avoid Out of Memory (OOM) errors.
 * Provide progress updates for long-running queries that may fail.
 
-### 3.2. Batches
+### Batches
 
 Attempting to query a large amount of data in one go can sometimes lead to timeouts.
 Based on my experience, if the first row cannot be extracted within 2 minutes, `simple_salesforce` will raise an exception.
@@ -323,7 +323,7 @@ def get_dates_batches(min_date, max_date, max_days_per_batch=None):
     return chunks
 ```
 
-## 4. Types of Fields
+## Types of Fields
 
 Fields (or Columns) in Salesforce are flexible and can contain different types of data. I classify fields into three types:
 
@@ -331,7 +331,7 @@ Fields (or Columns) in Salesforce are flexible and can contain different types o
 2. **Reference fields**: These are links to other tables, similar to a join.
 3. **Compound fields**: These are formulas based on other fields, including fields from referenced tables.
 
-### 4.1. Primitive Fields
+### Primitive Fields
 
 Primitive fields are the basic type of fields, providing information about the entity itself.
 For example, in the `User` table, primitive fields might include:
@@ -339,7 +339,7 @@ For example, in the `User` table, primitive fields might include:
 * `firstname`: The user's first name (string).
 * `age`: The user's age (integer).
 
-### 4.2. Reference Fields
+### Reference Fields
 
 Reference fields are links to other tables and behave similarly to a **join** in SQL.
 The two important parts of reference fields are:
@@ -356,7 +356,7 @@ Here are examples of reference fields:
 | Delegation__c    | reference | [Delegation__c] | Delegation__r    |
 | User__c          | reference | [User]          | User__r          |
 
-### 4.3. Compound Fields (Calculated Fields)
+### Compound Fields (Calculated Fields)
 
 Compound fields are populated at query time based on a formula.
 For example, in the `User` table, we might have `firstName` and `lastName` as primitive fields, with `fullName` defined as `FirstName & ’ ’ & LastName`. More information about compound fields can be found in <FancyLink linkText="Compound fields" url="https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/compound_fields.htm"/>.
@@ -375,7 +375,7 @@ When extracting data, compound fields are risky because:
 In the example above, modifying `User.FirstName` would result in a different `fullName`, but the `Order` table's `LastModifiedDate` would remain unchanged.
 This can lead to incorrect data extraction.
 
-### 4.4. Retrieving Field Information
+### Retrieving Field Information
 
 You can use `sf.Entity.describe()` to retrieve field definitions as a dictionary.
 This can be transformed into a Pandas DataFrame for easier viewing:
@@ -402,13 +402,13 @@ class Column(BaseModel):
     relationship
 ```
 
-## 5. Querying with External Changes
+## Querying with External Changes
 
 > [!warning]
 > After writing this post I discovered that I can simply use `SystemModstamp` for getting all changes done to an entity.
 > Here is the original content for reference, but **I strongly suggest you query with `SystemModstamp`** instead.
 
-### 5.1. The problem
+### The problem
 
 Compound fields can be calculated based on external entities.
 However, an update on the related entity does not change the `LastModifiedDate` of the main entity.
@@ -418,7 +418,7 @@ Let's illustrate this problem with an example where we want to query the `Delega
 
 ![Problem with external fields](../../images/posts/2024/0046-salesforce_external_fields.jpg)
 
-### 5.2. The solution
+### The solution
 
 To address this issue, we need to filter the `LastModifiedDate` of both entities when querying.
 To automate this process, we can retrieve all fields of type `reference` and check if their `relationshipName` is used in any `calculatedFormula`.
@@ -464,7 +464,7 @@ WHERE (LastModifiedDate >= {min_date} AND LastModifiedDate < {max_date})
 > [!warning]
 > You should replace `{min_date}` and `{max_date}` with datetimes with the format `%Y-%m-%dT%H:%M:%SZ` (do not include any `"` or `'`).
 
-#### 5.2.1. Deciding Date Ranges
+#### Deciding Date Ranges
 
 In regular runs, I query data from the last extraction (`max(LastUpdateDate)` from the table where the export will be stored) up until the current datetime (`datetime.now()`).
 More information about this approach can be found in <FancyLink linkText="Self-Healing Pipelines" url="https://villoro.com/blog/self-healing-pipelines/" dark="True"/>.
@@ -479,7 +479,7 @@ For example:
 
 When dealing with external entities, we only include the `min_date` since that date won't be used for the next execution to determine the next `min_date`.
 
-### 5.3. Automatically Detecting Related Entities
+### Automatically Detecting Related Entities
 
 To automate the detection of related entities, we can search for `relationshipName` entries in an entity and check if they are found in the `calculatedFormula` of any other field.
 This can be achieved using regular expressions:
@@ -526,7 +526,7 @@ def get_referenced_entities(entity):
 This function retrieves all fields of type `reference`, extracts their `relationshipName`, and checks if it appears in any `calculatedFormula`.
 If found, it adds the related entity to the query.
 
-### 5.4. Data size
+### Data size
 
 With this new approach, you will download rows whenever:
 
@@ -553,11 +553,11 @@ Other alternatives could be:
 * Letting the long process run and assuming the cost.
 * Triggering the pipeline more frequently, which could lead to smaller batches.
 
-## 6. Bonus: Final code
+## Bonus: Final code
 
 Here you can see the final code that is explained during the post
 
-### 6.1. Salesforce connector class
+### Salesforce connector class
 
 This is the code for querying salesforce:
 
@@ -789,7 +789,7 @@ class SalesForceConnector:
         return out
 ```
 
-### 6.2. Saleforce export
+### Saleforce export
 
 This is the python file that calls the queries and exports them:
 
@@ -910,7 +910,7 @@ def main(params):
 > [!note]
 > There are some functions that are not defined (such as `get_tables`, `infer_min_datetime` and `export_records`) since they are out of the scope of this post.
 
-## 7. Conclusion
+## Conclusion
 
 In this guide, we've explored various techniques for building robust data extraction pipelines from Salesforce, covering strategies to handle timeouts, avoid memory errors, and efficiently query related entities. By implementing these approaches, you can ensure reliable and scalable data retrieval processes tailored to your organization's needs.
 

--- a/src/content/blog/0047-install_windows.mdx
+++ b/src/content/blog/0047-install_windows.mdx
@@ -10,7 +10,7 @@ tags: [Tutorial, Setup, Windows]
 draft: false
 ---
 
-## 0. Motivation
+## Motivation
 
 I'm frequently installing Windows on computers because I believe periodic reinstalls improve PC performance and are essential when helping family members set up their PCs.
 A few months ago, I bought three Lenovo ThinkCentre minis for my family.
@@ -18,7 +18,7 @@ They are old but still quite powerful for lighter use.
 Since I needed to install Windows on these three computers, I decided to document the process to easily repeat it in the future.
 This guide serves as a comprehensive resource for anyone looking to perform a clean Windows installation.
 
-## 1. Download Windows
+## Download Windows
 
 You can easily download Windows from Microsoft's website.
 At this stage, you don't need a Windows license.
@@ -30,7 +30,7 @@ To download it, you should:
 
 This will allow you to create a bootable USB.
 
-## 2. Create bootable USB
+## Create bootable USB
 
 Use the `MediaCreationTool` to create a bootable USB.
 
@@ -47,7 +47,7 @@ This will trigger:
 2. Formatting the USB.
 3. Adding all needed files to the drive and making it bootable.
 
-## 3. Install Windows
+## Install Windows
 
 What we want to avoid is getting bloatware (as much as possible) when installing Windows.
 
@@ -55,7 +55,7 @@ This can be done by selecting `English (World)` or `English (Europe)` for the `T
 
 For more info, see: <FancyLink linkText="How to install Windows 11 without bloatware apps" url="https://pureinfotech.com/install-windows-11-without-bloatware-apps/" company="default" dark="true"/>.
 
-### 3.1. Clean the Disk
+### Clean the Disk
 
 After you have selected the region, you will need to decide where to install Windows.
 I like to go to the `Custom: Install Windows only (advanced)` option. With that, I can make sure to do a clean install.
@@ -65,7 +65,7 @@ I like to go to the `Custom: Install Windows only (advanced)` option. With that,
 
 Select the disk where you want to install Windows. If needed, delete the existing partitions and create a new one.
 
-## 4. Set up windows
+## Set up windows
  
 Here, we want to create a local account. This is because:
 
@@ -77,7 +77,7 @@ Given that you might be installing Windows for another user, I think this is the
 
 We will be following this guide: <FancyLink linkText="How to Install Windows 11 Without a Microsoft Account" url="https://www.tomshardware.com/how-to/install-windows-11-without-microsoft-account" company="default" dark="true"/>.
 
-### 4.1. OOBEREGION 'Error'
+### OOBEREGION 'Error'
 
 If you see the OOBEREGION error, don't panic.
 It just means that Windows is unable to determine which bloatware to install. Just skip that step.
@@ -85,7 +85,7 @@ It just means that Windows is unable to determine which bloatware to install. Ju
 > [!tip]
 > It's not an error. It means no bloatware will be installed.
 
-### 4.2. Disable Internet
+### Disable Internet
 
 When it asks for an internet connection, hit `SHIFT` + `F10`. A command prompt will appear. Then just write:
 
@@ -101,39 +101,39 @@ When it asks about the internet connection, select `I don't have internet`. Even
 
 From there, you can set up a username and you will have your local account.
 
-## 5. Install Programs
+## Install Programs
 
 Once you are inside Windows, you can connect to the internet to start downloading everything you need.
 
 Everyone has different preferences, but there is a way to get the most common programs and install them all at once. Just go to <FancyLink linkText="ninite.com" url="https://ninite.com/"/> and select the programs you want.
 Once done, hit `Get Your Ninite` to download an `ninite.exe` file that will install them all.
 
-### 5.1. Change the Default Browser (if desired)
+### Change the Default Browser (if desired)
 
 I don't like Edge, and you might not like it either.
 You can download any internet browser you want, but I suggest you try <FancyLink linkText="Brave" url="https://brave.com/"/>.
 
 It's the only browser that has a built-in ad blocker, which is quite useful for faster loading times and privacy.
 
-## 6. Configure the Computer
+## Configure the Computer
 
-### 6.1 Check Startup Apps
+### Check Startup Apps
 
 Here you might want to disable apps that you don't use so that the computer loads faster.
 For example, you might not be using `OneDrive` (which is installed even if you do the `English (world)` trick), and in that case, it would be better to disable it.
 
 To do so, open the `Task Manager` and go to `Startup apps`.
 
-### 6.2. Set the Timezone
+### Set the Timezone
 
 The only problem with selecting `English (World)` is that you probably won't have the correct timezone.
 Just right-click the Windows clock and go to `Adjust date and time`.
 
-### 6.3. Set Correct Windows Language
+### Set Correct Windows Language
 
 If needed, change the Windows language to whatever you want.
 
-### 6.4. Install Drivers
+### Install Drivers
 
 On modern computers, you might not need to do it.
 But if you are installing Windows on an old computer, you might need to install some drivers.
@@ -145,7 +145,7 @@ The most common ones I have needed to install are:
 
 Here, the best thing you can do is to Google your computer model and go to the official website of the brand and download anything you need.
 
-### 6.5. Install Office
+### Install Office
 
 You can download Microsoft Office directly from Microsoft's official Content Delivery Network (CDN) links:
 
@@ -154,15 +154,15 @@ You can download Microsoft Office directly from Microsoft's official Content Del
 
 After downloading, you can mount the image files to begin the installation. To mount an image, simply **right-click on the file and select `Mount`**. Once mounted, run the installer to set up Microsoft Office on your computer.
 
-## 7. Set up Windows
+## Set up Windows
 
-### 7.1. Windows updates
+### Windows updates
 
 Windows updates take a lot of time to install and sometimes can go wrong.
 So, I think it's best that you download all updates you can so that your computer is as updated as possible.
 This will usually require multiple restarts.
 
-### 7.2. Activate Windows
+### Activate Windows
 
 Some computers come with a working Windows key, and in certain cases, activation happens automatically. If this doesn't apply to you, it's **strongly recommended to activate Windows** to ensure you receive security updates and access all features.
 
@@ -173,7 +173,7 @@ I advise against using online activators that could introduce harmful changes to
 
 If you still insist on using an activator, ensure you understand the risks involved. A safer option in this regard is to refer to <FancyLink linkText="Microsoft Activation Scripts (MAS)" url="https://massgrave.dev/" company="default" dark="true"/>, a trusted community-maintained resource. However, this approach carries risks, and you should proceed at your own discretion.
 
-## 8. [Optional] Set up DNS
+## [Optional] Set up DNS
 
 Finally, you might want to change DNS. This will allow you to:
 

--- a/src/content/blog/0048-calls-open-ai.mdx
+++ b/src/content/blog/0048-calls-open-ai.mdx
@@ -10,11 +10,11 @@ tags: [Python, DE, AI, Tutorial, OpenAI]
 draft: false
 ---
 
-## 0. Motivation
+## Motivation
 
 At work we wanted to extract information from calls done using a CTI. This way we can improve the service we offer by getting insights from the call and by providing suggestions to agents. We can do that using different OpenAI models.
 
-## 1. How to extract insights from an audio with OpenAI
+## How to extract insights from an audio with OpenAI
 
 At the time of writing `ChatGPT 4o` is not able to process multimodal information. That means that we cannot pass an audio together with text to extract insights. To do so, we need to do it with 2 steps:
 
@@ -25,7 +25,7 @@ We will do it using <FancyLink linkText="OpenAI python" url="https://github.com/
 
 First, let's focus on the transcription.
 
-### 2. Using `Whisper` to transcribe the call
+### Using `Whisper` to transcribe the call
 
 With `whisper` we can transcribe an audio file easily.
 It can be done with:
@@ -59,7 +59,7 @@ transcription = transcribe_audio(client, file)
 
 This code assumes that the file is stored in `S3` but it can easily be adapted for local files or for other cloud providers.
 
-## 3. Handling invalid calls
+## Handling invalid calls
 
 When processing the first calls, I noticed that we had a lot of super short calls where no transcription could be extracted.
 Trying to transcribe those calls is a waste of resources.
@@ -113,7 +113,7 @@ def process_file(client, s3, filename):
     return transcription
 ```
 
-## 4. Adding metadata
+## Adding metadata
 
 I think that is always really useful to have some metadata whenever doing operations in the datalake.
 It will be specially useful when debugging issues.
@@ -155,7 +155,7 @@ With that, we can add this to the `process_file` function:
     )
 ```
 
-## 5. Using `ChatGPT` to Extract Insights
+## Using `ChatGPT` to Extract Insights
 
 To extract information, you can make a standard call to `ChatGPT`.
 The key here is to leverage the newly introduced structured outputs, which were announced recently (<FancyLink linkText="Introducing Structured Outputs in the API" url="https://openai.com/index/introducing-structured-outputs-in-the-api/"/>).
@@ -165,7 +165,7 @@ For more details, refer to the <FancyLink linkText="API Reference | response_for
 > Note that there is an option to directly provide a Pydantic class in the API call, which will automatically handle the casting.
 > However, since this feature is still in beta, I prefer not to use it at this time.
 
-### 5.1. Defining the Prompt with a Pydantic Model
+### Defining the Prompt with a Pydantic Model
 
 To ensure consistency and avoid code duplication, we'll start by creating a <FancyLink linkText="Pydantic" url="https://docs.pydantic.dev/"/> class that defines the structure and fields of the output:
 

--- a/src/content/blog/0049-open-ai-async.mdx
+++ b/src/content/blog/0049-open-ai-async.mdx
@@ -10,7 +10,7 @@ tags: [API, Best Practices, DE, OpenAI, Python]
 draft: false
 ---
 
-## 0. Motivation
+## Motivation
 
 In a previous post (<FancyLink linkText="Process Calls with Open AI" url="https://villoro.com/blog/transcribe-audios-whisper-extract-structured-data-chatgpt/" dark="true"/>), we explored how to extract insights from audio recordings using OpenAI models.
 While extracting insights is critical, fully automating this process presents additional challenges, primarily in managing API quota limits and efficiently handling multiple concurrent API calls.
@@ -21,7 +21,7 @@ This post addresses these challenges by demonstrating how to implement a rate li
 By ensuring compliance with API quotas and dynamically handling limits, you can maximize the throughput of your requests while maintaining service reliability.
 Whether you're using **Whisper** for transcription or **ChatGPT** for extracting insights, this guide will help you streamline operations, avoid common pitfalls, and optimize the use of OpenAI's powerful capabilities.
 
-## 1. Approach overview
+## Approach overview
 
 To efficiently manage concurrent API calls to OpenAI while respecting rate limits, we use a two-pronged approach:
 
@@ -31,9 +31,9 @@ To efficiently manage concurrent API calls to OpenAI while respecting rate limit
 
 Combining these strategies enables the processing of a large volume of API requests both efficiently and reliably. By structuring outputs using Pydantic models, we ensure that data remains organized and easily manageable. This approach not only optimizes performance but also preserves the integrity and reliability of data processing tasks, making it well-suited for scaling up operations.
 
-## 2. Quota limits
+## Quota limits
 
-### 2.1. Understanding OpenAI Rate Limits
+### Understanding OpenAI Rate Limits
 
 OpenAI enforces rate limits to manage API usage effectively, ensuring fair use and stable performance for all users. The primary metrics to consider are:
 
@@ -44,7 +44,7 @@ OpenAI enforces rate limits to manage API usage effectively, ensuring fair use a
 
 The specific rate limits vary by subscription tier. For more details, refer to <FancyLink linkText="Open AI | Rate Limits" url="https://platform.openai.com/docs/guides/rate-limits"/>.
 
-### 2.2. Managing Rate Limits
+### Managing Rate Limits
 
 Understanding and managing these limits is essential, especially when scaling operations or integrating with automated workflows. Here's how to handle them effectively:
 
@@ -105,12 +105,12 @@ def count_tokens(messages, model=MODEL_TOKENIZER_DEFAULT):
 > [!note]
 > The `GPTTokens` class will be used to track actual token usage during API calls, which will be detailed in the following sections.
 
-## 3. Rate Limiter
+## Rate Limiter
 
 We use a Rate Limiter to prevent exceeding API usage limits, ensuring compliance and avoiding throttling or service disruptions.
 This approach maximizes the number of valid requests per minute.
 
-### 3.1. How It Works
+### How It Works
 
 The `RateLimiter` class is designed to monitor and control both request and token usage.
 It initializes with specified limits for maximum requests (`max_requests`) and tokens (`max_tokens`).
@@ -274,7 +274,7 @@ class RateLimiter:
 > This overlap is intentional, as using `update_from_headers` ensures more accurate limit management and optimizes the number of valid requests per minute.
 > By relying on actual API feedback, we can better handle fluctuating limits and reduce the risk of hitting rate caps unexpectedly.
 
-## 4. Using the Rate Limiter with Async calls
+## Using the Rate Limiter with Async calls
 
 As seen in <FancyLink linkText="Process Calls with Open AI" url="https://villoro.com/blog/transcribe-audios-whisper-extract-structured-data-chatgpt/" dark="true"/> we were using the <FancyLink linkText="OpenAI python" url="https://github.com/openai/openai-python" dark="true"/> package.
 This simplifies the process but prevents us from getting relevant data from the headers (as explained in <FancyLink linkText="Rate limits in headers | Open AI" url="https://platform.openai.com/docs/guides/rate-limits/rate-limits-in-headers"/>).
@@ -285,7 +285,7 @@ That data is really useful for knowning:
 
 Since this will help us getting more accurate information which in turn will help us increase the number of requests we can do, we will do manual requests to the API.
 
-### 4.1. Calling the API
+### Calling the API
 
 We will use <FancyLink linkText="Aiohttp" url="https://github.com/aio-libs/aiohttp" dark="true"/> for making API requests.
 The general approach is similar to what is descrived in <FancyLink linkText="Best strategy on managing concurrent calls ? (Python/Asyncio)" url="https://community.openai.com/t/best-strategy-on-managing-concurrent-calls-python-asyncio/849702/2"/>.
@@ -298,7 +298,7 @@ A semaphore is also used to limit the number of concurrent calls, ensuring that 
 
 In the next section, you will see the full code for making calls to both Chat and Transcription endpoints.
 
-### 4.2. Calling the Transcription endpoint
+### Calling the Transcription endpoint
 
 For transcriptions, we use `whisper-1`, which does not have specific RPM (Requests Per Minute) limits.
 This makes the code simpler compared to the one used for `Chat`.
@@ -412,7 +412,7 @@ If a rate limit is exceeded, indicated by a `HTTP 429` error, it retries the req
 
 The `call_openai_transcription` function manages the preparation of input data for the API call and formats the output as a Pydantic object for structured response handling (more details on this can be found in <FancyLink linkText="Process Calls with Open AI" url="https://villoro.com/blog/transcribe-audios-whisper-extract-structured-data-chatgpt" dark="true"/>).
 
-### 4.3. Calling the Chat Endpoint
+### Calling the Chat Endpoint
 
 Calls to the `Chat` endpoint are quite similar to those for `Transcriptions`.
 The key differences are that we need to manage the number of tokens used in each request and ensure that the output is structured according to a Pydantic class.
@@ -547,7 +547,7 @@ async def call_openai_chat(
     return ChatOutput(id=id, gpt_tokens_used=usage, **result_json)
 ```
 
-### 4.4. Utils
+### Utils
 
 I use a utils file for setting the headers needed for the API calls and to control the number of concurrent jobs with a Semaphore.
 
@@ -586,12 +586,12 @@ def split_valid_and_invalid_records(records, pydantic_model):
     return valid_results, invalid_results
 ```
 
-## 5. Doing batches
+## Doing batches
 
 The idea is to initialize the `RateLimiter` with the limits for each endpoint and to then do all concurrent calls asynchronously with `asyncio.gather`.
 Finally since the outputs are always a pydantic class we can easily transform the results to a pandas dataframe so that we can export it as a table.
 
-### 5.1. Transcriptions in batches
+### Transcriptions in batches
 
 Here is the code for the transcriptions:
 
@@ -617,7 +617,7 @@ async def async_call_open_ai_transcription(files, gpt_model=DEFAULT_MODEL):
     return pd.DataFrame([x.dict() for x in output]), errors
 ```
 
-### 5.2. Chats in batches
+### Chats in batches
 
 The code for chats is very similar.
 The only difference is that here we allow to return the text as is (if wanted) or to get structured data as a pydantic class.
@@ -656,7 +656,7 @@ async def async_call_open_ai_chat(
     return pd.DataFrame([x.dict() for x in output]), errors
 ```
 
-## 6. Further Reading and Resources
+## Further Reading and Resources
 
 * <FancyLink linkText="Process Calls with Open AI" url="https://villoro.com/blog/transcribe-audios-whisper-extract-structured-data-chatgpt/" dark="true"/>
 * <FancyLink linkText="Best strategy on managing concurrent calls ? (Python/Asyncio)" url="https://community.openai.com/t/best-strategy-on-managing-concurrent-calls-python-asyncio/849702/2"/>

--- a/src/content/blog/0050-small_files.mdx
+++ b/src/content/blog/0050-small_files.mdx
@@ -10,7 +10,7 @@ tags: [DE, Performance, Spark, dbt]
 draft: false
 ---
 
-## 0. Motivation
+## Motivation
 
 In modern data lake architectures, managing the size and number of files is crucial for maintaining performance and cost-efficiency.
 During my work, I frequently encountered tables with a huge number of small files, which led to very poor query performance and significantly increased costs.
@@ -20,13 +20,13 @@ After investing considerable time into tracking and fixing these problems, I wan
 
 This post aims to provide a comprehensive guide on understanding, identifying, and resolving the small file problem in data lakes, ensuring that your data processing remains efficient and cost-effective.
 
-## 1. What's the problem
+## What's the problem
 
 In data lakes, managing the size of partitions is crucial for maintaining optimal performance and cost-efficiency.
 Partitions that are too small, generally less than 1 GB, can significantly degrade performance and inflate costs.
 This issue is well-documented in the <FancyLink linkText="Delta Lake Optimisation Guide" url="https://www.linkedin.com/pulse/delta-lake-optimisation-guide-deenar-toraskar/"/>, which highlights the adverse effects of small partitions on data processing and querying efficiency.
 
-### 1.1. Performance
+### Performance
 
 According to the article <FancyLink linkText="Fixing the Small File Problem in Data Lake with Spark" url="https://medium.com/@satadru1998/%EF%B8%8F-fixing-the-small-file-problem-in-data-lake-with-spark-2cc9fbb86796" dark="true"/>:
 
@@ -34,21 +34,21 @@ According to the article <FancyLink linkText="Fixing the Small File Problem in D
 
 This is because small files increase the number of tasks required to process the data, leading to higher overhead in task management and scheduling. Each task incurs a startup cost, and when there are many small tasks, this overhead can accumulate, resulting in significant slowdowns.
 
-### 1.2. Costs
+### Costs
 
 Another significant issue with small file partitions is the impact on costs.
 When I was working at Glovo, my colleagues observed that reducing the number of small files in heavily queried tables resulted in a **10x cost reduction**.
 
 This significant saving was primarily due to the decreased number of `S3 GET requests`, which are a major cost factor when querying small files.
 
-### 1.3. Default Behavior of Data Lake Writers
+### Default Behavior of Data Lake Writers
 
 By default, many data lake writers tend to create a large number of small files.
 For instance, Apache Spark will write multiple small files if not properly configured.
 Similarly, with AWS Athena, it is challenging to control the file sizes, often resulting in tiny files being created.
 If not set up correctly, these default behaviors can lead to a proliferation of small files, exacerbating performance and cost issues in the data lake.
 
-## 2. Good file size
+## Good file size
 
 Determining the optimal file size in a data lake can be challenging, as it depends on various factors such as the data processing engine, query patterns, and specific workload characteristics.
 However, most documentation and data processing engines recommend targeting a file size **around 1 GB**.
@@ -60,12 +60,12 @@ Similarly, the <FancyLink linkText="DuckDB | Parquet File Sizes" url="https://du
 > [!tip]
 > Around **1 GB per file** is the usual target for optimal file size in data lakes.
 
-## 3. How to avoid it?
+## How to avoid it?
 
 The key to avoiding small files in your data lake is to control the number of files written during data processing.
 Ensuring that the files are of optimal size improves both performance and cost-efficiency.
 
-### 3.1. Spark
+### Spark
 
 In Spark, you can control the number of files written by using the `sdf.repartition(n_files)` function, which allows you to specify the number of partitions (and hence the number of output files).
 Additionally, you can configure Spark to manage the size of files by setting the minimum and maximum number of rows per file through the configuration options `spark.sql.files.maxRecordsPerFile` and `spark.sql.files.minRecordsPerFile`.
@@ -74,7 +74,7 @@ Additionally, you can configure Spark to manage the size of files by setting the
 > Using `repartition` can cause significant shuffling of data, which might lead to performance issues.
 > The number of partitions also affects Spark's parallelization; too few partitions can lead to underutilized resources, while too many can cause excessive overhead.
 
-### 3.2. Athena with dbt
+### Athena with dbt
 
 > [!warning]
 > In AWS Athena, **there is no direct way to control the number of files** written during query execution.
@@ -153,7 +153,7 @@ models:
       - "{{ vacuum() }}"
 ```
 
-## 4. Good partitioning
+## Good partitioning
 
 When it comes to partitioning tables in a data lake, it's important to consider the type of data and its usage patterns.
 There are generally two types of tables:
@@ -162,7 +162,7 @@ There are generally two types of tables:
 
 * **Aggregated (or presentation) tables**: These tables represent a final snapshot or aggregated view of the data. They often don't need to be partitioned unless the dataset is very large. Partitioning might not be necessary for these tables as they are typically queried in their entirety or by specific dimensions that do not benefit significantly from partitioning.
 
-### 4.1. Partitioning Fact tables
+### Partitioning Fact tables
 
 For fact tables, while partitioning by time is common, it can be more efficient to avoid partitioning if it leads to small files.
 Using data formats like <FancyLink linkText="Delta Lake" url="https://delta.io/"/> or <FancyLink linkText="Apache Iceberg" url="https://iceberg.apache.org/" company="iceberg"/> can help manage this.
@@ -182,13 +182,13 @@ See <FancyLink linkText="Iceberg | Partition Transforms" url="https://iceberg.ap
 
 This is possible because of <FancyLink linkText="Iceberg's hidden partitioning" url="https://iceberg.apache.org/docs/1.4.0/partitioning/#icebergs-hidden-partitioning" company="iceberg"/>.
 
-## 5. How to track the problem
+## How to track the problem
 
 Tracking the number of files and partitions each table has is crucial for managing data lakes efficiently.
 Both Iceberg and Delta provide ways to query the metadata, which can then be exported into a table.
 Ideally, this data should be exported every time a table is written.
 
-### 5.1. Iceberg
+### Iceberg
 
 With Iceberg, you can query the `files` metadata, which gives you detailed information such as:
 
@@ -213,7 +213,7 @@ SELECT
 FROM {{ this.schema }}."{{ this.table }}$files";
 ```
 
-#### 5.1.1. Iceberg in Spark
+#### Iceberg in Spark
 
 According to the official documentation (<FancyLink linkText="Spark: Querying with SQL | Iceberg" url="https://iceberg.apache.org/docs/latest/spark-queries/#querying-with-sql" company="iceberg"/>), you can query the `files` metadata with:
 
@@ -284,7 +284,7 @@ While Iceberg can handle concurrent write operations, issues can sometimes occur
 Therefore, retries with <FancyLink linkText="Backoff" url="https://github.com/litl/backoff" dark="true"/> are recommended.
 For more information, see <FancyLink linkText="Concurrent write operations | Iceberg" url="https://iceberg.apache.org/docs/1.4.1/reliability/#concurrent-write-operations" company="iceberg"/>.
 
-#### 5.1.2. Iceberg in Athena with dbt
+#### Iceberg in Athena with dbt
 
 You can query the `files` metadata with:
 
@@ -408,7 +408,7 @@ models:
       - "{{ export_metadata() }}" # <-- Add this
 ```
 
-#### 5.1.3. Track `files_by_day`
+#### Track `files_by_day`
 
 Now that we have a table with a snapshot of the metadata for each table whenever there is a write, we can create a table that tracks the latest state by day.
 This table will help us monitor partitioning problems.
@@ -539,7 +539,7 @@ models:
         tests: [not_null]
 ```
 
-### 5.2. Delta
+### Delta
 
 With Delta, you can use the `DESCRIBE DETAIL table` command to get similar information.
 This produces a table like this:
@@ -555,19 +555,19 @@ You can read more about this in the docs <FancyLink linkText="Review Delta Lake 
 
 For tracking metadata, you can follow a similar approach to what was described for Iceberg.
 
-## 6. Fixing the problem
+## Fixing the problem
 
 After following the previous steps, you have detected multiple tables that are not well partitioned and have a lot of small files.
 What can you do to fix the data?
 
-### 6.1. Non partitioned tables
+### Non partitioned tables
 
 For non-partitioned tables, it is quite straightforward. You can simply run `OPTIMIZE` to compact the table.
 
 > [!warning]
 > The `OPTIMIZE` command can take a lot of time and might require a lot of processing power, depending on the table size. Proceed with caution.
 
-### 6.2. Partitioned tables
+### Partitioned tables
 
 For partitioned tables, the best case scenario is where you can compact the partitions with `OPTIMIZE`, similar to non-partitioned tables.
 If you want, you can optimize only some partitions, which will be faster and require less computing power.
@@ -575,7 +575,7 @@ If you want, you can optimize only some partitions, which will be faster and req
 If compacting the partitions is not enough, you will need to change the partitioning of the table.
 This process differs for Delta and Iceberg tables.
 
-### 6.2.1. Partitioned Delta tables
+### Partitioned Delta tables
 
 Delta tables have fixed partitioning, and you **cannot change the partitioning** of an existing table.
 Therefore, you will need to recreate the table without the partition column or with a different partitioning.
@@ -615,7 +615,7 @@ Once everything is good with the new table, you can recreate the original table:
 3. Move back all the data.
 4. Delete the temporary table.
 
-### 6.2.2. Partitioned Iceberg tables
+### Partitioned Iceberg tables
 
 With Iceberg, you can perform schema evolutions, such as changing the partitioning.
 You can read more about it at <FancyLink linkText="Iceberg evolutions" url="https://iceberg.apache.org/docs/nightly/evolution/"/>.
@@ -628,7 +628,7 @@ However, there is a caveat:
 To compact old partitions, you still need to move the data to a temporary table and then bring it back.
 You can follow a similar approach to what was described for Delta tables.
 
-## 7. Conclusion
+## Conclusion
 
 Managing the size and number of files in a data lake is essential for maintaining optimal performance and controlling costs.
 Throughout this post, we've explored the challenges posed by small files, the ideal file sizes recommended by various data processing engines, and practical strategies for avoiding and fixing these issues.

--- a/src/content/blog/0051-amd-tdp.mdx
+++ b/src/content/blog/0051-amd-tdp.mdx
@@ -12,7 +12,7 @@ draft: false
 
 <script type="module" src="/js/posts/0051-plots-amd-tdp.js"></script>
 
-## 0. Motivation
+## Motivation
 
 Last year, I bought a <FancyLink linkText="Geekom AS6" url="https://www.geekompc.com/geekom-as-6-mini-pc/"/> and I'm really happy with it.
 It has an integrated GPU (680M) that allows me to play most modern games at 1080p, such as Resident Evil 4 Remake.
@@ -21,7 +21,7 @@ I bought it since it's almost identical to the <FancyLink linkText="Asus PN53" u
 It has been working really well until summer arrived.
 Due to high temperatures, the CPU was shutting down because of excessive heat.
 
-## 1. What's the problem
+## What's the problem
 
 I have been using <FancyLink linkText="Open Hardware Monitor" url="https://openhardwaremonitor.org/"/> to track and store multiple data from the computer, such as temperatures, load, and power consumption.
 
@@ -39,34 +39,34 @@ The problem I had is that under high load in summer, temperatures were too high:
 > The CPU load looks low because I was gaming at the time (GPU intensive).
 > GPU load is not tracked nor included in the CPU load, which is why it looks like the computer was close to idle.
 
-## 2. Regular ways to prevent overheating
+## Regular ways to prevent overheating
 
 Here are the most common ways to prevent overheating.
 
-### 2.1. Changing TDP on the BIOS
+### Changing TDP on the BIOS
 
 Many computers allow you to lower the Thermal Design Power (TDP) to reduce the CPU's wattage, helping to prevent overheating.
 
 However, some PCs (such as mine) do not have this option.
 
-### 2.2. Undervolting
+### Undervolting
 
 Another method is undervolting the CPU with a tool like <FancyLink linkText="MSI Afterburner" url="https://www.msi.com/Landing/afterburner/graphics-cards"/>. It doesn't work for all computers and can be dangerous.
 
 > [!warning]
 > Undervolting can permanently damage your computer, proceed with caution.
 
-### 2.3. Dedicated software
+### Dedicated software
 
 Some PCs have dedicated software.
 For example, for AMD, there is <FancyLink linkText="AMD Software: Adrenalin Edition™ Application" url="https://www.amd.com/en/products/software/adrenalin.html"/> and <FancyLink linkText="AMD Ryzen™ Master Utility for Overclocking Control" url="https://www.amd.com/en/products/software/ryzen-master.html"/>.
 However, I couldn't change the TDP on my computer with either of these tools.
 
-## 3. Using RyzenAdj
+## Using RyzenAdj
 
 After having no luck with the previous methods, I discovered <FancyLink linkText="RyzenAdj" url="https://github.com/FlyGoat/RyzenAdj" dark="true"/>, which allows you to configure multiple settings for your AMD Ryzen CPU.
 
-### 3.1. Check current setup
+### Check current setup
 
 First, download RyzenAdj to a folder (like `C:\AMD`).
 Then, check the current setup with:
@@ -100,7 +100,7 @@ You will see information like this:
 > [!note]
 > I pivoted the table so that it's easier to read.
 
-### 3.2. What to change with RyzenAdj
+### What to change with RyzenAdj
 
 There are multiple ways to prevent overheating. In my case, I want to change:
 
@@ -118,7 +118,7 @@ After tracking temperatures and CPU usage, I settled for:
 | PPT SLOW |  40.0 | slow-limit  |
 | THM CORE |  90.0 | tctl-temp   |
 
-### 3.3. Limit TDP and Temperature
+### Limit TDP and Temperature
 
 To apply the changes, simply run:
 
@@ -135,7 +135,7 @@ Then validate that the limits are properly set up:
 | PPT SLOW |   8.3 | <span style="background-color:PaleGreen;">40.0</span> | slow-limit  |
 | THM CORE |  53.0 | <span style="background-color:PaleGreen;">90.0</span> | tctl-temp   |
 
-## 4. Stress testing
+## Stress testing
 
 Once you have changed the limits, you should test that your computer does not overheat.
 You can do this with <FancyLink linkText="3D Mark" url="https://benchmarks.ul.com/3dmark" company="default" dark="true"/> or <FancyLink linkText="AIDA64" url="https://www.aida64.com/downloads" company="default" dark="true"/> (among others).
@@ -148,12 +148,12 @@ Here are my results:
 > [!tip]
 > You can see that the TDP remains at 40 W and that the temperature never reaches the danger zone (above 95 ºC).
 
-## 5. Limit TDP at start up
+## Limit TDP at start up
 
 Unfortunately, the changes made by `ryzenadj.exe` will only work for the current session.
 Once you restart your PC, you will need to apply them again.
 
-### 5.1. Create Scheduled Task
+### Create Scheduled Task
 
 To automatically apply them at start up, you can create a `Scheduled Task`.
 
@@ -186,7 +186,7 @@ To do so:
     * Click `OK`.
     * You may be prompted to enter your administrator password to create the task.
 
-### 5.2. Verify Scheduled Task
+### Verify Scheduled Task
 
 To ensure the task works correctly, restart your computer and validate that the limits are correctly applied with:
 

--- a/src/content/blog/0052-terramaster-nas.mdx
+++ b/src/content/blog/0052-terramaster-nas.mdx
@@ -10,25 +10,25 @@ tags: [NAS, Hardware, Terramaster]
 draft: false
 ---
 
-## 0. Motivation
+## Motivation
 
 After purchasing the <FancyLink linkText="Terramaster F2-424" url="https://amzn.to/40CRZqJ" company="amazon"/> NAS, I decided to document my setup process. This guide serves as both a personal reference in case I need to reinstall and a practical guide for others who might be setting up a similar NAS configuration.
 
-## 1. About the hardware
+## About the hardware
 
 For anyone considering a NAS, here’s a summary of my experience and the choices I made for my setup.
 
-### 1.1. The NAS
+### The NAS
 
 Previously, I had a Synology D115J, but its CPU wasn’t quite powerful enough for my needs. I wanted a NAS capable of running multiple Docker containers, which required a more robust processor. After researching Synology and QNAP models, I found that their budget options were often limited by outdated CPUs.
 
 That’s when I came across the Terramaster NAS lineup. Although I initially had reservations about Terramaster's Operating System (TOS), reviews suggested that it was straightforward to replace TOS with options like Unraid or TrueNAS if needed. Ultimately, I decided on a 2-bay NAS for simplicity, choosing fewer but larger disks for storage capacity. The <FancyLink linkText="Terramaster F2-424" url="https://amzn.to/40CRZqJ" company="amazon"/> offered the best balance of power and flexibility for my setup.
 
-### 1.2. The Hard Drives
+### The Hard Drives
 
 When selecting drives, I prioritized models rated for 24/7 operation, essential for NAS use. Initially, I purchased <FancyLink linkText="Seagate Exos X18 3.5 16TB" url="https://amzn.to/3O2h2vX" company="amazon"/> drives because they were cost-effective. However, the noise level turned out to be too disruptive, especially with the NAS housed in a cabinet near my living room. Fortunately, I was able to exchange them for <FancyLink linkText="Seagate IronWolf Pro 3.5 NAS 16TB" url="https://amzn.to/4eopD6G" company="amazon"/> drives (at an additional 90€ per drive). Although pricier, the IronWolf Pro drives are significantly quieter and better suited to my setup.
 
-### 1.3. The SSDs
+### The SSDs
 
 To keep my NAS as silent as possible, I added the <FancyLink linkText="WD Red SN700 1TB NVMe SSD" url="https://amzn.to/42rH5Vj" company="amazon" />.
 It's a NAS-grade SSD rated at 2000 TBW — a high endurance rating that should ensure a long lifespan.
@@ -36,19 +36,19 @@ It's a NAS-grade SSD rated at 2000 TBW — a high endurance rating that should e
 > [!note]
 > My goal was to install TOS on the SSD, allowing the HDDs to go into sleep mode when not in use — reducing both wear and noise.
 
-### 1.4. The UPS
+### The UPS
 
 To protect the NAS from potential power outages, I opted for a UPS with a USB connection, enabling automatic shutdown of the NAS during an outage. I chose the <FancyLink linkText="Master Power (UPS 650 VA - 360W)" url="https://amzn.to/3YDj7Dw" company="amazon"/> as a budget-friendly option, which is ideal for low-power devices like my NAS. This UPS provides just enough backup power to safely handle brief outages and help prevent data loss.
 
-## 2. Initial Setup
+## Initial Setup
 
 For a detailed installation guide, you may want to consult the <FancyLink linkText="Terramaster Quickguide" url="https://support.terra-master.com/quickguide/" company="terramaster"/>. Here, I’ll highlight the steps that were most relevant for my setup.
 
-### 2.1. Locating the NAS
+### Locating the NAS
 
 To begin, you’ll need to locate the NAS on your network. With a Terramaster NAS, simply navigate to <FancyLink linkText="tnas.local" url="http://tnas.local" dark="true" company="default"/>. After a few clicks, you should see the NAS IP displayed. If that doesn’t work, you can use a network analysis app, such as <FancyLink linkText="Fing" url="https://www.fing.com"/>, to find the NAS IP.
 
-### 2.2. Install Terramaster OS (TOS)
+### Install Terramaster OS (TOS)
 
 To install TOS on the SSD:
 
@@ -61,7 +61,7 @@ This process will partition each selected SSD to install the OS. While the insta
 > [!note]
 > I decided to install TOS only on the main SSD and then use the secondary SSD (not a NAS SSD) as cache.
 
-## 3. Network Configuration
+## Network Configuration
 
 Many users opt to use a secondary router rather than the one provided by their Internet Service Provider (ISP). ISP-provided routers often have limited features and performance. However, adding a secondary router can introduce double NAT, which can cause connectivity issues. You can learn more about double NAT and its effects in this <FancyLink linkText="guide" url="https://medium.com/@gmanual/double-nat-explained-and-possible-solutions-8b41b6c651bd" dark="true"/>.
 
@@ -74,7 +74,7 @@ Since I couldn’t enable bridge mode on my ISP router, I opted for the DMZ setu
 > [!warning]
 > Note: These steps may vary depending on your router models and network configuration. Refer to your router’s manual for model-specific instructions.
 
-### 3.1. Reserve an IP for your secondary router
+### Reserve an IP for your secondary router
 
 To set up a DMZ, the first step is to assign a static IP to your secondary router:
 
@@ -82,7 +82,7 @@ To set up a DMZ, the first step is to assign a static IP to your secondary route
 2. Access your **ISP router’s configuration** page.
 3. In the DHCP settings, **create a DHCP binding** for the secondary router, preferably using its current IP for simplicity.
 
-### 3.2. DMZ
+### DMZ
 
 Once the IP is reserved, follow these steps to set up the DMZ:
 
@@ -90,14 +90,14 @@ Once the IP is reserved, follow these steps to set up the DMZ:
 2. Locate the **DMZ settings**.
 3. Enable the DMZ and assign it to the static IP of your secondary router.
 
-## 4. Handling storage
+## Handling storage
 
 Once TOS installation is complete, you can create your superuser account. Afterward, you’re ready to configure storage on the NAS.
 
 > [!note]
 > You can use letters, numbers, and special characters in your passwords, with a maximum length of 64 characters.
 
-### 4.1. Creating a storage pool
+### Creating a storage pool
 
 > [!tip]
 > You might want to first create the storage pool for the SSDs and install the apps.
@@ -112,11 +112,11 @@ For storage formats, you can choose between `EXT4` and `BTRFS`. While both have 
 > [!note]
 > HDDs will be noisy during storage pool creation (RAID synchronization). Noise will decrease once synchronization completes and during regular usage.
 
-### 4.2. Hyper Cache
+### Hyper Cache
 
 You can use one of the two M.2 SSD slots for caching. This can enhance `read`, `write`, or `balanced` performance, depending on your NAS’s primary tasks.
 
-### 4.3. SMD and connecting externally
+### SMD and connecting externally
 
 There are different ways to connect to the NAS. My preferred method is mapping a network drive. To do this, you need to enable SMB:
 
@@ -124,7 +124,7 @@ There are different ways to connect to the NAS. My preferred method is mapping a
 2. Go to `Network Services > File Service`.
 3. Under the `SMB` tab, enable it (you can keep the default settings).
 
-### 4.4. Options for adding data
+### Options for adding data
 
 The NAS model I chose has two 2.5 Gbps Ethernet ports, which typically support file transfer speeds around 250–280 MB/s. Alternatively, you can use USB 3.1 Gen 1 with an external SSD, potentially achieving speeds between 300–400 MB/s. However, the Ethernet option is generally more efficient, as using an external SSD requires first copying data to the SSD, then transferring it to the NAS.
 
@@ -133,7 +133,7 @@ Note that your transfer speeds may be limited by the RAID configuration and the 
 > [!tip]
 > For optimal performance, I recommend transferring data over Ethernet rather than using an external USB drive.
 
-## 5. Connecting locally (SSH)
+## Connecting locally (SSH)
 
 When setting up applications, it can be very useful to access the NAS via a terminal (`ssh`), allowing direct command-line interaction.
 
@@ -161,7 +161,7 @@ Replace:
 > [!warning]
 > To minimize security risks, disable `SSH` once setup is complete and you no longer need terminal access.
 
-## 6. Installing Apps
+## Installing Apps
 
 The  `App Center` on your TerraMaster NAS allows you to install applications from both the official `Terramaster` repository and the `Community` repository.
 
@@ -171,7 +171,7 @@ For my setup, I installed:
 * **Docker** (including `Docker Engine`, `Docker Manager` and `Portainer`)
 * **Tailscale** (community app) for secure remote access
 
-### 6.1. Plex
+### Plex
 
 Plex setup is simple:
 
@@ -184,7 +184,7 @@ For easier access, I recommend creating the Plex libraries within the `Public` f
 > You might have problems claiming the server if you are accessing the NAS over tailscale.
 > To set it up, **use the NAS IP** instead.
 
-### 6.2. qBittorrent
+### qBittorrent
 
 Upon installing qBittorrent, an `admin` user is created with the password `adminadmin`.
 
@@ -204,7 +204,7 @@ Suggested Download Configuration:
 
 This setup keeps everything organized and makes it easy to monitor new and completed downloads.
 
-### 6.3. Tailscale
+### Tailscale
 
 Tailscale, a community app, enables secure remote connections. Download it from the <FancyLink linkText="Tailscale | TerraMaster Community Place" url="https://tmnascommunity.eu/download/tailscale/" dark="true" company="default"/>and install it manually via `App Center/Settings/Install application manually`.
 
@@ -220,7 +220,7 @@ To authenticate, visit:
 
 2. Visit this URL to register the NAS with your Tailscale account. Once added, it will appear in your Tailscale admin console (optionally, rename it to nas for easy identification).
 
-#### 6.3.1. Set the NAS as an Exit Node
+#### Set the NAS as an Exit Node
 
 Optionally, you can configure the NAS as an exit node:
 
@@ -242,7 +242,7 @@ tailscale set --advertise-exit-node
 tailscale set --auto-update
 ```
 
-### 6.4. Docker and portainer
+### Docker and portainer
 
 This is quite straightforward. The only important thing is that default Portainer credentials are:
 
@@ -251,7 +251,7 @@ This is quite straightforward. The only important thing is that default Portaine
 
 Remember to change them at the first login.
 
-## 7. UPS Configuration
+## UPS Configuration
 
 To safeguard against power outages, connecting the NAS to a UPS is highly recommended. Some UPS models offer USB connectivity, which allows the NAS to receive a shutdown signal during power interruptions.
 

--- a/src/content/blog/0053-terramaster-mega.mdx
+++ b/src/content/blog/0053-terramaster-mega.mdx
@@ -10,23 +10,23 @@ tags: [NAS, Hardware, Terramaster, Docker]
 draft: false
 ---
 
-## 0. Motivation
+## Motivation
 
 In this guide, I'll walk you through installing and configuring MEGASync on a TerraMaster NAS using Docker. This setup is particularly useful because **TOS CloudSync doesn't support MEGA**, leaving users with limited options for seamless synchronization with MEGA cloud storage. Using Docker, you can overcome this limitation and enjoy a fully functional sync setup.
 
 If you're just starting with your TerraMaster NAS, I recommend checking out my previous post <FancyLink linkText="Setting Up and Optimizing a Terramaster NAS" url="https://villoro.com/blog/setting-up-terramaster-nas/" dark="true"/>, where I cover the basics to get your device up and running. Once your NAS is set up, this guide will help you extend its functionality with MEGASync.
 
-## 1. About TOS Paths
+## About TOS Paths
 
 TerraMaster's TOS handles user directories in a specific way that can sometimes cause confusion or issues with Docker containers. While user folders are displayed in TOS under `/home/<username>`, these directories are actually mapped internally to `/Volume1/User/<username>`. This discrepancy can lead to problems with Docker containers, particularly when they require consistent and predictable file paths.
 
-### 1.1. Shared Folders for Sync
+### Shared Folders for Sync
 
 In my setup, `Volume1` is the SSD where the OS is installed, and `Volume2` is the RAID volume for the HDDs.
 
 To store personal data on the HDDs, you need to create a shared folder on `Volume2` and assign access to the user who will use it. For example, you can create a shared folder named `<username>_data` to store all personal data for that user.
 
-### 1.2. Proposed Directory Structure for MEGASync
+### Proposed Directory Structure for MEGASync
 
 I recommend the following paths for MEGASync:
 
@@ -36,7 +36,7 @@ I recommend the following paths for MEGASync:
 - **Synced Data**: `/Volume2/<username>_data`  
   Storing data in the shared folder ensures easy access and reduces the chance of conflicts with other applications.
 
-## 2. Run the MEGASync Docker Container
+## Run the MEGASync Docker Container
 
 You can set up MEGASync either via the terminal or by using Portainer. Choose the option that works best for you.
 
@@ -54,7 +54,7 @@ You can use the following command to see which ports are free to use:
 netstat -tuln | grep LISTEN
 ```
 
-### 2.1. Option 1: Using the Terminal
+### Option 1: Using the Terminal
 
 Run the following command:
 
@@ -74,7 +74,7 @@ docker run -d \
 > [!warning]
 > Replace `<admin_username>` and `<username>` with your actual values.
 
-### 2.2. Option 2: Using Portainer
+### Option 2: Using Portainer
 
 Use the following configuration:
 
@@ -105,7 +105,7 @@ Restart Policy: Always
 
 After entering all the configuration in Portainer, click `Deploy the container`.
 
-## 3. Access the MEGASync Web Interface
+## Access the MEGASync Web Interface
 
 Once the container is running, access the MEGASync interface by opening your browser and navigating to:
 
@@ -129,7 +129,7 @@ Once configured, you can access the settings anytime via the `Mega` icon on the 
 
 ![Pipeline DAG example](../../images/posts/2024/0053-megasync-icon-settings.jpg)
 
-## 4. Verify the Setup
+## Verify the Setup
 
 - Monitor the container logs to ensure there are no errors:
   ```bash
@@ -138,7 +138,7 @@ Once configured, you can access the settings anytime via the `Mega` icon on the 
 
 - Test synchronization by adding files to `/Volume2/<username>_data` and confirming they appear in your MEGA account (and vice versa).
 
-## 5. Adding Multiple Users
+## Adding Multiple Users
 
 This setup is designed to work for multiple users. To sync another user, repeat the steps to run the Docker container. Use the new username in all relevant paths and container names. For example:
 
@@ -149,20 +149,20 @@ This setup is designed to work for multiple users. To sync another user, repeat 
 
 By doing so, each user will have their own isolated MEGAsync instance.
 
-## 6. Troubleshooting
+## Troubleshooting
 
-### 6.1. Permission Denied Errors
+### Permission Denied Errors
 
 If you encounter permission errors, verify the volume paths are set correctly and accessible to the Docker container.
 
 > [!tip]
 > You can also test whether the issue is related to permissions by temporarily setting the data path to `777`.
 
-### 6.2. Logs Indicate Missing Commands
+### Logs Indicate Missing Commands
 
 Errors like `xrdb: command not found` are harmless and can be ignored.
 
-### 6.3. Access Issues
+### Access Issues
 
 Ensure the container is running:
 

--- a/src/content/blog/0054-s3-costs.mdx
+++ b/src/content/blog/0054-s3-costs.mdx
@@ -12,7 +12,7 @@ draft: false
 
 <script type="module" src="/js/posts/0054-plots-s3-costs.js"></script>
 
-## 0. Motivation
+## Motivation
 
 Amazon S3 is a powerful, scalable storage solution integral to many workflows. However, storage costs can quickly accumulate, especially when managing large datasets. After migrating some of our jobs from EMR to ECS, S3 storage emerged as our largest expense.
 
@@ -23,9 +23,9 @@ By analyzing our storage usage and implementing targeted strategies, we successf
 > [!tip]
 > This guide outlines how to export an S3 Inventory and implement Lifecycle Policies to track and optimize your storage expenses effectively.
 
-## 1. Categorizing S3 Costs
+## Categorizing S3 Costs
 
-### 1.1 Discover S3 Costs with Cost Explorer
+### Discover S3 Costs with Cost Explorer
 
 The first step is to examine your AWS costs by service using the **Cost Explorer**. This allows you to identify which service to target for cost reduction. In our case, after optimizing EMR costs, S3 became the next clear objective:
 
@@ -47,11 +47,11 @@ In our case, most costs stemmed from storage. However, in some organizations, hi
 > [!tip]
 > If you’re incurring high S3 request costs, check out <FancyLink linkText="Solving the Problem with Small Files in the Data Lake" url="https://villoro.com/blog/solving-problem-small-files-data-lake/" dark="true" /> for strategies to address this issue.
 
-### 1.2 Create an S3 Inventory Configuration
+### Create an S3 Inventory Configuration
 
 **S3 Inventory** is a feature in Amazon S3 that generates scheduled reports containing a comprehensive list of objects in a bucket, along with their metadata. This helps you analyze and manage storage efficiently.
 
-#### 1.2.1. Steps to Set Up S3 Inventory:
+#### Steps to Set Up S3 Inventory:
 
 1. **Access the S3 Console:**
    Log in to the AWS Management Console and navigate to the S3 service.
@@ -76,14 +76,14 @@ In our case, most costs stemmed from storage. However, in some organizations, hi
    * Review your configuration.
    * Save it by clicking **Create**.
 
-#### 1.2.2. Notes on Destination Path:
+#### Notes on Destination Path:
 
 The destination path will include additional folders automatically. For example, if your destination path is `s3://villoro/s3_inventory` for a bucket named `villoro` and inventory name `villoro_inventory`, the final path will be `s3://villoro/s3_inventory/villoro/villoro_inventory/`.
 
 > [!note]
 > The first report will be available within 48 hours, and subsequent reports will be generated based on the frequency you selected.
 
-### 1.3 Accessing the S3 Inventory
+### Accessing the S3 Inventory
 
 The S3 Inventory follows a unique structure. Reports are stored at `destination_path/bucket_name/inventory_name/`. The structure includes:
 
@@ -91,7 +91,7 @@ The S3 Inventory follows a unique structure. Reports are stored at `destination_
 - **Data Folder:** Contains the data files from all exports.
 - **Hive Folder:** Includes symlinks to the timestamped folders for easier querying.
 
-#### 1.3.1. Example Structure:
+#### Example Structure:
 
 ```plaintext
 - s3://villoro/s3_inventory/villoro/villoro_inventory/
@@ -112,7 +112,7 @@ The S3 Inventory follows a unique structure. Reports are stored at `destination_
           └──symlink.txt
 ```
 
-#### 1.3.2. Example Manifest File:
+#### Example Manifest File:
 
 ```json
 {
@@ -130,11 +130,11 @@ The S3 Inventory follows a unique structure. Reports are stored at `destination_
 }
 ```
 
-## 2. Extracting Data from the Inventory
+## Extracting Data from the Inventory
 
 To create a standard Iceberg table from the non-conventional folder structure of the S3 inventory, we need to process the manifest files, extract the corresponding Parquet data, and then structure it into a usable table. Removing source data after processing is also recommended to optimize storage.
 
-### 2.1 Creating an S3 Inventory Table
+### Creating an S3 Inventory Table
 
 The main steps involve:
 
@@ -279,7 +279,7 @@ if __name__ == "__main__":
 
 ```
 
-### 2.2 Cleaning the Data with dbt
+### Cleaning the Data with dbt
 
 Below are the four models used to structure and clean the inventory data:
 
@@ -494,7 +494,7 @@ Below are the four models used to structure and clean the inventory data:
   ```
 </Accordion>
 
-### 2.3 Analyzing the Inventory
+### Analyzing the Inventory
 
 Once the data is consolidated in an Iceberg table, analysis can be customized based on your needs. Examples of what we analyzed:
 
@@ -502,14 +502,14 @@ Once the data is consolidated in an Iceberg table, analysis can be customized ba
 2. **Exploring Folders:** Dive into folder-level details for high-priority categories.
 3. **Comparing Layers:** Compare `bronze` and `silver` layers for the same entities to identify discrepancies.
 
-#### 2.3.1. Insights Gained
+#### Insights Gained
 
 1. **Ineffective File Deletion:** We found that files in our largest bucket were not being deleted effectively.
 2. **Append-Only Tables:** Some `bronze` tables were only appending data without deletions, leading to unnecessary storage costs.
 
 The first issue was addressed with an S3 Lifecycle Policy (details in the next section). The second issue, while significant, is beyond the scope of this post.
 
-## 3. Implement S3 Lifecycle Policies
+## Implement S3 Lifecycle Policies
 
 S3 Lifecycle Policies automate object management to reduce costs. For instance, you can transition objects to cheaper storage classes or delete non-current versions. Here’s how to set them up:
 

--- a/src/content/blog/0055-astral-uv-ruff.mdx
+++ b/src/content/blog/0055-astral-uv-ruff.mdx
@@ -13,17 +13,17 @@ draft: false
 <script type="module" src="/js/posts/0055-plots-astral.js"></script>
 
 
-## 0. Introduction: Virtual Environment and Linting Tools
+## Introduction: Virtual Environment and Linting Tools
 
 When working with Python, managing dependencies and ensuring clean code are essential tasks. Over the years, the Python ecosystem has developed multiple tools for these purposes, but there is no universal agreement on which one to use. Tools like `pipenv`, `venv`, `poetry`, and `conda` all offer different ways to manage environments and dependencies, while linters like `flake8`, `pylint`, and `black` aim to enforce style and correctness.
 
 Astral, the creators of `ruff`, have introduced a new tool called `uv`—a blazing-fast virtual environment and package manager built in Rust. Since both `uv` and `ruff` share the same goal of significantly improving Python workflows through speed and efficiency, this post will explore both tools and why they might be the best options for modern Python development.
 
-## 1. Why `uv` is a Game-Changer
+## Why `uv` is a Game-Changer
 
 I previously recommended `poetry` for dependency management (see <FancyLink linkText="Managing Package Versions with Poetry" url="https://villoro.com/blog/managing-package-versions-with-poetry/" dark="true"/>), but `uv` has since proven to be a superior choice. Unlike `poetry`, which is written in Python, `uv` is built with Rust, making it significantly faster. It offers a simple interface while maintaining compatibility with standard `pip` and `venv` workflows.
 
-### 1.1. Installing `uv`
+### Installing `uv`
 
 To install `uv`, simply run:
 
@@ -43,7 +43,7 @@ Or, if using `brew` on macOS:
 brew install astral-sh/uv/uv
 ```
 
-### 1.2. Single-Script Execution and Ad-Hoc Dependencies
+### Single-Script Execution and Ad-Hoc Dependencies
 
 One of `uv`'s standout features is the ability to execute scripts with dependencies without manually managing a virtual environment:
 
@@ -62,7 +62,7 @@ uv add --script example.py 'requests<3' 'rich'
 
 This makes `uv` an excellent choice for quick experiments or one-off scripts that need isolated dependencies.
 
-### 1.3. Initializing a Project
+### Initializing a Project
 
 To create a new Python project with `uv`, run:
 
@@ -72,7 +72,7 @@ uv init
 
 This will prompt you to enter project details like name, version, and dependencies. It will create `pyproject.toml` and `.python-version`.
 
-### 1.4. Creating a Virtual Environment
+### Creating a Virtual Environment
 
 A major feature of `uv` is its fast virtual environment management:
 
@@ -89,7 +89,7 @@ uv venv --python=3.11 .venv
 > [!note]
 > If a `.python-version` file exists, `uv` will automatically use the specified version.
 
-### 1.5. Installing Dependencies
+### Installing Dependencies
 
 Install packages like you would with `pip`:
 
@@ -105,7 +105,7 @@ uv pip install --editable .
 
 This ensures your local code changes reflect immediately when running scripts.
 
-### 1.6. Running Commands in an Isolated Environment
+### Running Commands in an Isolated Environment
 
 Unlike traditional virtual environment tools, `uv` lets you run commands directly without needing to activate the environment:
 
@@ -114,7 +114,7 @@ uv run python script.py
 uv run pytest
 ```
 
-### 1.7. Handling Editable Installs and Running a Package
+### Handling Editable Installs and Running a Package
 
 One issue many users face with `uv` is running a local package. If you are working with a structured project (e.g., using `src/` layout), the correct way to install and execute it is:
 
@@ -125,13 +125,13 @@ uv run python -m src.main
 
 This ensures that the installed package is properly recognized when executing it as a module.
 
-## 2. `ruff`: The Ultra-Fast Linter and Formatter
+## `ruff`: The Ultra-Fast Linter and Formatter
 
 Linters and formatters are essential for maintaining clean and readable code. Traditionally, `flake8`, `black`, and `pylint` have been widely used, but they are slow due to being written in Python.
 
 Enter `ruff`, a Rust-based linter that combines linting, formatting, and import sorting into a single, high-performance tool. It serves as a replacement for `flake8`, `black`, `isort`, and even `mypy`-style type checking in some cases.
 
-### 2.1. Installing `ruff`
+### Installing `ruff`
 
 To install `ruff`, use:
 
@@ -145,7 +145,7 @@ Or, for even better performance, use `uv`:
 uv pip install ruff
 ```
 
-### 2.2. Running `ruff`
+### Running `ruff`
 
 To check your Python files, simply run:
 
@@ -161,11 +161,11 @@ ruff format .
 
 This command is a drop-in replacement for `black` but executes significantly faster.
 
-## 3. CI/CD Integration
+## CI/CD Integration
 
 Here you have some common recipes for integrating `uv` and `ruff` with **CI/CD** workflows.
 
-### 3.1. Running `ruff` with `pre-commit`
+### Running `ruff` with `pre-commit`
 
 For CI/CD workflows, you can use `pre-commit` with:
 
@@ -178,7 +178,7 @@ For CI/CD workflows, you can use `pre-commit` with:
     - id: ruff-format
 ```
 
-### 3.2. Exporting `uv` Dependencies
+### Exporting `uv` Dependencies
 
 In some setups, you might need a `requirements.txt`. For example, when working with `Prefect` it expects that file.
 To generate the `requirements.txt` file run:
@@ -197,7 +197,7 @@ For CI/CD workflows, you can use `pre-commit` to ensure dependencies are always 
       args: ["--no-hashes", "--frozen", "--output-file=requirements.txt"]
 ```
 
-### 3.3. Running Tests with `uv`
+### Running Tests with `uv`
 
 To run tests inside the virtual environment:
 
@@ -229,7 +229,7 @@ For GitHub Actions:
   ```
 </Accordion>
 
-### 3.4. Publishing to PyPI with `uv`
+### Publishing to PyPI with `uv`
 
 To build and publish a package to PyPI using `uv`:
 
@@ -264,11 +264,11 @@ For automation, add this to GitHub Actions:
 > I strongly suggest you set up <FancyLink linkText="Trusted publishers in pypi" url="https://docs.pypi.org/trusted-publishers/adding-a-publisher/"/> to avoid adding tokens.
 > It's the prefered way of uploading packages to pypi.
 
-## 4. Benchmarks: How Fast Are `uv` and `ruff`?
+## Benchmarks: How Fast Are `uv` and `ruff`?
 
 Rust-based tooling provides substantial speed improvements over Python-based alternatives. The following benchmarks are sourced from the <FancyLink linkText="Official Astral documentation" url="https://docs.astral.sh/"/>:
 
-### 4.1. `uv` benchmarks
+### `uv` benchmarks
 
 At <FancyLink linkText="uv benchmarks" url="https://github.com/astral-sh/uv/blob/main/BENCHMARKS.md" dark="true"/> you can see a very comprehensive speed analysis.
 
@@ -276,7 +276,7 @@ For quick reference here is a summary:
 
 <canvas id="astral_uv" style="width:100%;height:400px;"></canvas>
 
-### 4.2. `ruff` benchmarks
+### `ruff` benchmarks
 
 Here you can see the time it took to format <FancyLink linkText="Zulip" url="https://github.com/zulip/zulip" dark="true"/> codebase (~ 250k lines of code).
 
@@ -284,7 +284,7 @@ Here you can see the time it took to format <FancyLink linkText="Zulip" url="htt
 
 More info at <FancyLink linkText="Ruff formatter" url="https://astral.sh/blog/the-ruff-formatter"/> .
 
-## 5. Conclusion
+## Conclusion
 
 Astral’s tools, `uv` and `ruff`, provide a powerful, high-performance alternative to traditional Python package management and linting solutions. By leveraging Rust’s efficiency, they dramatically reduce execution time while maintaining full compatibility with existing workflows.
 

--- a/src/content/blog/0056-glue-versions.mdx
+++ b/src/content/blog/0056-glue-versions.mdx
@@ -12,7 +12,7 @@ draft: false
 
 <script type="module" src="/js/posts/0056-glue-versions.js"></script>
 
-## 0. What happened?
+## What happened?
 
 We hit a strange issue with dbt Athena where no queries were running:
 
@@ -27,7 +27,7 @@ Until then, I was totally unaware that:
 > [!danger]
 > Glue has a **hard limit** of **1 000 000 schema versions** across the **entire Glue catalog**.
 
-## 1. Glue versions
+## Glue versions
 
 Almost all the tables we write are **Iceberg**, which manages schema evolution more effectively under the hood. From an Iceberg perspective, we **don’t need Glue versioning at all** — it’s a side effect of using Glue as a catalog.
 
@@ -49,7 +49,7 @@ In our case:
 
 The version bloat was entirely invisible... until it wasn’t.
 
-### 1.1. Glue versions in dbt
+### Glue versions in dbt
 
 On the dbt side, the impact was smaller — but not zero.
 
@@ -68,7 +68,7 @@ In our case, it's not needed because we use `materialized = table`, so our table
 
 So while dbt wasn't the main contributor to version bloat, **it still affected our total version count through view models.**
 
-## 2. How to clean old versions
+## How to clean old versions
 
 I wrote a script that:
 * Iterates over all databases
@@ -108,7 +108,7 @@ You might wonder why we still have an average of ~100 versions per table. That�
 
 Here's the full code we used, broken down in sections:
 
-### 2.1. Getting database and tables info
+### Getting database and tables info
 
 ```python
 from datetime import datetime, timedelta, timezone
@@ -142,7 +142,7 @@ def get_versions(database, table, client=None):
     return out
 ```
 
-### 2.2. Cleaning versions of a table with batches
+### Cleaning versions of a table with batches
 
 ```python
 def _chunked(iterable, size):
@@ -192,7 +192,7 @@ def clean_old_glue_table_versions(database, table, min_versions, retention_days)
     return len(version_ids)
 ```
 
-### 2.3. Cleaning the whole catalog
+### Cleaning the whole catalog
 
 ```python
 def clean_one_database(database, min_versions, retention_days):
@@ -221,7 +221,7 @@ def process(min_versions=MIN_VERSIONS, retention_days=RETENTION_DAYS):
     logger.info(f"{len(databases)} databases proccessed with {total_deletes=}")
 ```
 
-## 3. Performance gains
+## Performance gains
 
 What surprised us the most was that **Athena performance improved dramatically**, even though dbt wasn’t contributing much to the version bloat.
 
@@ -238,7 +238,7 @@ Our main pipelines became faster:
 > Even if you use dbt and aren’t generating many Glue versions, it’s worth checking.
 > After reducing the catalog size, we saw up to **4× faster** execution in Athena.
 
-## 4. Takeaways
+## Takeaways
 
 * Be aware of the **1 000 000-version hard limit** in the Glue Catalog — it's not just theoretical.
 * If you're using **Spark, or AWS Wrangler** to write tables, version bloat is almost guaranteed.

--- a/src/content/blog/0057-smoothing.mdx
+++ b/src/content/blog/0057-smoothing.mdx
@@ -12,7 +12,7 @@ draft: false
 
 <script type="module" src="/js/posts/0057-smoothing.js"></script>
 
-## 0. Why Smoothing Matters (and Why It’s Not That Simple)
+## Why Smoothing Matters (and Why It’s Not That Simple)
 
 I’ve spent hours—maybe days—trying to find the "perfect" way to smooth a time series. I didn’t just want a trend line—I wanted a smoothed *series*—the kind you often see in polished dashboards, where the noise fades and the pattern becomes obvious. I remembered seeing some tools that seemed to use something close to a Gaussian smoother, and that became my benchmark.
 
@@ -26,7 +26,7 @@ To do so, I'll use the following time series with daily data:
 
 ![Source data](../../images/posts/2025/0057-source-data.jpg)
 
-## 1. Timeframe Reduction
+## Timeframe Reduction
 The simplest way to smooth a time series is by reducing its granularity.
 
 **Pros:**
@@ -40,7 +40,7 @@ The simplest way to smooth a time series is by reducing its granularity.
 
 <canvas id="plot_source" style="width:100%;height:300px;"></canvas>
 
-## 2. Smoothing with Python: From Simple to Smart
+## Smoothing with Python: From Simple to Smart
 
 ### 🔁 Moving Average
 A moving average is the most common starting point for smoothing. It replaces each point with the average of its neighbors over a fixed-size window.
@@ -109,7 +109,7 @@ df["lowess"] = smoother.smooth_data[0]
 
 <canvas id="plot_lowess" style="width:100%;height:300px;"></canvas>
 
-## 3. Smoothing with SQL: What’s Possible, What’s Not
+## Smoothing with SQL: What’s Possible, What’s Not
 
 ### ❌ Why no Gaussian or Lowess in SQL?
 Techniques like Gaussian smoothing and Lowess require iterative, weighted, and often non-linear computations—something SQL just isn't designed for. You can’t easily apply convolution or perform local regressions inside a SQL query.
@@ -188,7 +188,7 @@ ORDER BY 1 DESC
 
 ---
 
-## 4. Side-by-Side Comparison
+## Side-by-Side Comparison
 
 To wrap up, we’ll place all techniques side by side:
 

--- a/src/content/blog/0058-pipeline-failures.mdx
+++ b/src/content/blog/0058-pipeline-failures.mdx
@@ -10,13 +10,13 @@ tags: [SQL, DE, Best Practices, dbt, Prefect]
 draft: false
 ---
 
-## 0. Motivation
+## Motivation
 
 Failures are inevitable in any data pipeline — whether due to API timeouts, schema changes, network issues, or bugs in transformation logic. Over time, we’ve learned that simply reacting to failures as they occur leads to inconsistent data, broken downstream systems, and painful debugging sessions.
 
 This post outlines a more structured, proactive approach. By treating failure handling as a first-class citizen of pipeline design — not just an afterthought — we can recover faster, minimize business impact, and maintain trust in our data products. The ETU framework and failure handling strategies described here are the result of real-world lessons and aim to create pipelines that are resilient by design.
 
-## 1. Pipeline Stages - ETU Paradigm
+## Pipeline Stages - ETU Paradigm
 
 Before we can talk about handling failures effectively, it's important to first describe the structure of our pipeline.
 
@@ -24,19 +24,19 @@ Before we can talk about handling failures effectively, it's important to first 
 > Our pipeline resembles a modern ELT process but with an important addition: we include a final step that pushes transformed data back into external systems — a practice often called Reverse ETL.
 > To capture this full lifecycle, we describe our approach as **ETU**: Extract, Transform, Upload.
 
-### 1.1. ⬇️ Extract & Load (E)
+### ⬇️ Extract & Load (E)
 
 In this first phase, we move data from various external sources into our data lake. These sources include APIs, SQL databases (e.g., Postgres, MySQL), and other systems. The data is ingested and registered in our Glue Data Catalog, enabling downstream discoverability and schema management.
 
-### 1.2. ⚙️ Transform (T)
+### ⚙️ Transform (T)
 
 Once the raw data lands in the lake, we use dbt to transform it into clean, structured, and enriched datasets. These transformations include filtering, joining, and applying business logic to create models that are ready for analysis or operational use.
 
-### 1.3. ⬆️ Upload (U)
+### ⬆️ Upload (U)
 
 In the final step, we push processed data back into third-party systems. This might include CRM platforms, advertising tools, or other business systems that require fresh data to function effectively. This step ensures the data lifecycle comes full circle, making insights actionable.
 
-### 1.4. ETU Stage Summary
+### ETU Stage Summary
 
 | Stage                 | Goal                                  | Tools / Mechanism | Output / Target                               |
 | --------------------- | ------------------------------------- | ----------------- | --------------------------------------------- |
@@ -48,9 +48,9 @@ Here is a really simple example of how our pipeline looks like:
 
 ![Pipeline DAG example](../../images/posts/2025/0058-pipeline-stages.jpg)
 
-## 2. Handling Failures in Different Stages
+## Handling Failures in Different Stages
 
-### 2.1. Failures in Extract & Load (E) ⬇️
+### Failures in Extract & Load (E) ⬇️
 
 Data needs to be successfully extracted and landed in the lake before dbt transformations can begin. These upstream extract jobs — often orchestrated outside dbt — are susceptible to failures, and how we handle those failures directly impacts downstream processing.
 
@@ -69,7 +69,7 @@ This job can partially succeed — transcribing some files but failing others du
 
 However, when the transcription job partially failed and I excluded its tag in the dbt run, the corresponding models weren’t updated. This led to reprocessing already-transcribed files, inflating compute costs and duplicating results.
 
-### 2.2. Failures in Transform (T) ⚙️
+### Failures in Transform (T) ⚙️
 
 The Transform step (T) is where dbt takes raw data from the lake and builds structured models. If something goes wrong in transformation, pushing bad or incomplete data into external systems can create inconsistencies or break business processes. For example, syncing `users` but not `sessions` could result in mismatched reporting.
 
@@ -82,7 +82,7 @@ dbt assigns one of six statuses to each node:
 * **success**: a `model` that ran successfully
 * **pass**: a `test` that met requirements
 
-#### 2.2.1. Strategies to Handle Failures
+#### Strategies to Handle Failures
 
 Before triggering the Upload (U) step, it’s important to inspect dbt results and decide which entities can safely be synced. We've used two main approaches:
 
@@ -95,7 +95,7 @@ Both strategies aim to prevent syncing stale or partial datasets while allowing 
 > [!note]
 > This selective approach protects downstream systems from receiving broken or incomplete data and reduces the risk of cascading failures.
 
-#### 2.2.2. Handling Failures
+#### Handling Failures
 
 The idea is to be able to know which models succeeded and which failed.
 
@@ -105,7 +105,7 @@ This can be done by:
 2. Exporting dbt run results
 3. Reading run results
 
-##### 2.2.2.1. Getting a Unique Execution ID
+##### Getting a Unique Execution ID
 
 It is really important to pass some ID to dbt so that we can match the run results with the actual run.
 
@@ -125,13 +125,13 @@ def get_flow_run_id():
         raise RuntimeError(msg)
 ```
 
-##### 2.2.2.2. Exporting dbt Run Results
+##### Exporting dbt Run Results
 
 I already described this in a previous post. You can read it at <FancyLink linkText="Running dbt with AWS ECS (Fargate) | 8.2. dbt run results" url="https://villoro.com/blog/running-dbt-with-aws-ecs-fargate/#82-dbt-run-results" dark="true"/>.
 
 The important part is to pass the `flow_run_id` to dbt so that it can be added as a column. This will allow us to filter later the run results we want.
 
-##### 2.2.2.3. Reading the results
+##### Reading the results
 
 Here is how we can query the results of a dbt run:
 
@@ -307,11 +307,11 @@ async def run_uploads(flow_run_id, env: Literal["snd", "pro"] = "pro"):
     )
 ```
 
-### 2.3. Failures in Upload (U) ⬆️
+### Failures in Upload (U) ⬆️
 
 Failures in upload jobs need no special treatment since there are no jobs that depend on them.
 
-## 3. Letting Tasks Fail Gracefully
+## Letting Tasks Fail Gracefully
 
 Sometimes you don’t want the failure of a single task to stop an entire pipeline. For example, you may be downloading multiple tables from a CRM inside an ECS or EMR job. Each table is processed in series using a synchronous flow. If one fails, you'd still want the rest to run — and only after finishing, handle and report any failures. In parallel, multiple of these jobs (e.g., for different sources) may be triggered as independent async flows.
 
@@ -324,7 +324,7 @@ Here you can see one example of how a failure in one extraction didn't block the
 
 ![Pipeline DAG example](../../images/posts/2025/0058-extract-failure.png)
 
-### 3.1. Handling Sync Flows
+### Handling Sync Flows
 
 This is how we can continue executing tasks whenever one fails:
 
@@ -360,7 +360,7 @@ def main():
 
 This pattern gives your pipeline flexibility and resilience, helping you avoid total failure just because one piece breaks.
 
-### 3.2. Handling Async Flows
+### Handling Async Flows
 
 Here’s how to run async flows concurrently while collecting and reporting failures:
 

--- a/src/content/blog/0059-vpn-tailscale.mdx
+++ b/src/content/blog/0059-vpn-tailscale.mdx
@@ -10,17 +10,17 @@ tags: [Tools, Setup, Security, Networking]
 draft: false
 ---
 
-## 0. What is a VPN and Why Use One?
+## What is a VPN and Why Use One?
 A Virtual Private Network (VPN) is a tool that establishes a secure and encrypted connection over the internet. It serves different purposes depending on the use case:
 
 - **Privacy and security**: Encrypting your internet traffic to prevent tracking by ISPs, advertisers, and potential attackers on public networks.
 - **Access and bypassing restrictions**: Allowing users to access geo-restricted content or bypass network censorship.
 - **Remote network access**: Connecting securely to a private network as if you were physically present in that location.
 
-## 1. Commercial VPNs vs Private Network VPNs
+## Commercial VPNs vs Private Network VPNs
 There are two main categories of VPNs, each serving a distinct purpose:
 
-### 1.1. Commercial VPNs
+### Commercial VPNs
 These services are designed primarily for privacy, security, and accessing restricted content. They provide:
 
 - **Encrypted traffic**: Protecting data from surveillance and attackers.
@@ -29,10 +29,10 @@ These services are designed primarily for privacy, security, and accessing restr
 
 A good example of a commercial VPN is <FancyLink linkText="Surfshark" url="https://surfshark.club/friend/FgNz9XN5"/> (you can use this link to get 3 months for free), which offers strong encryption, a no-logs policy, and the ability to connect unlimited devices under one subscription. If your goal is to protect your online privacy and bypass restrictions, a service like Surfshark is a solid choice.
 
-### 1.2. VPNs for Private Networks
+### VPNs for Private Networks
 These VPNs are used to securely connect to private resources, such as internal company networks, home servers, or self-hosted services. Unlike commercial VPNs, their goal is not anonymity or bypassing restrictions but rather secure access to specific resources.
 
-## 2. Tailscale: A Simpler Approach to Private Network VPNs
+## Tailscale: A Simpler Approach to Private Network VPNs
 Traditional VPN setups for private access often require complex configurations, managing IP addresses, and dealing with NAT traversal issues. <FancyLink linkText="Tailscale" url="https://tailscale.com/"/> simplifies this by using WireGuard and a mesh network approach:
 
 - **Automatic peer-to-peer connections**: Devices connect directly without needing a central VPN server.
@@ -43,10 +43,10 @@ With Tailscale, you can easily access your home server, NAS, or even remote desk
 
 Personally, I use Tailscale to securely access my NAS. One particularly useful feature is the ability to share access with my work email, which adds an extra layer of security by requiring two-step authentication. Additionally, I can easily revoke access whenever I want, ensuring I maintain control over who can connect.
 
-### 2.1. Tailnet and How IPs Work
+### Tailnet and How IPs Work
 When you set up Tailscale, all connected devices form a private network called a **tailnet**. Each device gets a unique and persistent internal IP address (typically in the `100.x.x.x` range), allowing direct communication without needing manual network configurations. This means you can securely access any device in your tailnet from anywhere, just as if they were on the same local network.
 
-### 2.2. MagicDNS from Tailscale
+### MagicDNS from Tailscale
 Another useful feature from Tailscale is **MagicDNS**, which allows devices to resolve DNS queries efficiently across a Tailscale network. This means:
 
 - Accessing local domain names from anywhere.
@@ -57,7 +57,7 @@ For example, instead of remembering IP addresses, you can simply access your NAS
 
 Additionally, MagicDNS supports **multiple tailnets**, meaning that if you use a work tailnet while also being part of your personal tailnet, it can resolve short names across both networks. This makes it even easier to access your devices without worrying about manually handling DNS settings across different environments.
 
-### 2.3. More Advanced Features of Tailscale
+### More Advanced Features of Tailscale
 Tailscale also includes several powerful features that enhance security and usability:
 
 - **Tailscale SSH** – Allows you to securely SSH into any device within your tailnet without opening ports or managing SSH keys manually.
@@ -65,7 +65,7 @@ Tailscale also includes several powerful features that enhance security and usab
 - **Keyless Authentication with OIDC** – Users can authenticate via identity providers like Google, Microsoft, or GitHub, eliminating the need for manually managed credentials.
 - **Subnet Routing** – Enables a single Tailscale-connected device to provide access to an entire network, making it easy to bridge remote offices or access devices that don’t natively support Tailscale.
 
-### 2.4. Tailscale Exit Nodes: Bypassing Subscription Restrictions
+### Tailscale Exit Nodes: Bypassing Subscription Restrictions
 One of the most powerful features of Tailscale is **Exit Nodes**, which allows you to route your internet traffic through another device on your Tailscale network. This is useful for:
 
 - **Privacy and security**: Routing traffic through a trusted location.

--- a/src/content/blog/0060-duckdb.mdx
+++ b/src/content/blog/0060-duckdb.mdx
@@ -12,7 +12,7 @@ draft: false
 
 <script type="module" src="/js/posts/0060-plots-duckdb.js"></script>
 
-## 1. What is DuckDB?
+## What is DuckDB?
 
 <FancyLink linkText="DuckDB" url="https://duckdb.org/" dark="true"/> is often described as **“SQLite for analytics”**. Like SQLite, it’s an embedded database engine that runs directly on your machine, but it’s designed for analytical workloads rather than transactional ones. This makes it an incredibly convenient tool for anyone working with data: no server to install, no cluster to spin up—just query your data where it is.
 
@@ -21,18 +21,18 @@ draft: false
 
 <FancyLink linkText="DuckDB" url="https://duckdb.org/" dark="true"/> sits in the sweet spot between lightweight tools like Pandas and heavyweight distributed systems like Spark. It’s fast, simple, and surprisingly powerful for working with large datasets on a single machine.
 
-## 2. Why DuckDB is Faster Than You Expect
+## Why DuckDB is Faster Than You Expect
 
 At first glance, you might assume DuckDB is only useful for medium-sized datasets that fit in memory. In reality, it consistently pushes the boundaries of what’s possible on a single machine.
 
 > [!tip]
 > In independent and first‑party benchmarks, DuckDB routinely handles **hundreds of millions to billions of rows** on commodity hardware and often beats heavier frameworks on local workloads—see the sources in each subsection below.
 
-### 2.1. How it achieves speed (in short)
+### How it achieves speed (in short)
 
 DuckDB’s engine is **columnar & vectorized** and aggressively **multithreaded**, with a push‑based pipeline and out‑of‑core operators when memory is tight. If you want the gory details (and tuning tips), the official performance guide is a great, concise tour: <FancyLink linkText="DuckDB Performance Guide" url="https://duckdb.org/docs/stable/guides/performance/overview.html" dark="true"/>.
 
-### 2.2. What the numbers say (real‑world speed benchmarks)
+### What the numbers say (real‑world speed benchmarks)
 
 * **Against dataframes on a laptop (10M rows generation/joins):** On a MacBook Pro M2 (16 GB), DuckDB completed the task in **3.84 s**, vs **5.77 s** for Polars (\~**1.5×** slower) and **19.57 s** for Pandas (\~**5.1×** slower). Source: <FancyLink linkText="DuckDB, Polars and Pandas performance comparison" url="https://github.com/prrao87/duckdb-study" dark="true"/>.
 
@@ -43,7 +43,7 @@ DuckDB’s engine is **columnar & vectorized** and aggressively **multithreaded*
 > [!warning]
 > Spark shines when scaling to terabytes across clusters, but on tens of GB, DuckDB often wins due to zero cluster overhead.
 
-### 2.3. Surprising scale on a single machine (larger‑than‑memory)
+### Surprising scale on a single machine (larger‑than‑memory)
 
 DuckDB’s **external (out‑of‑core) aggregation** lets you process data far bigger than RAM by spilling intelligently and recomputing pointers instead of (de)serializing.
 
@@ -54,7 +54,7 @@ DuckDB’s **external (out‑of‑core) aggregation** lets you process data far 
 > [!tip]
 > DuckDB’s out-of-core operators allow billion-row queries on a laptop—something unheard of just a few years ago.
 
-### 2.4. It keeps getting faster (measured over time)
+### It keeps getting faster (measured over time)
 
 On a standard benchmark suite (5 GB scale for mixed workloads; 50 GB for group‑bys/joins) run on an M1 MacBook Pro (16 GB), total runtime fell from **\~500 s (DuckDB 0.2.7, Jun 2021)** to **< 35 s (DuckDB 1.0.0, Jun 2024)**—a **\~14× improvement**. Source: <FancyLink linkText="Benchmarking Ourselves over Time" url="https://duckdb.org/2024/06/26/benchmarks-over-time.html" dark="true"/>.
 
@@ -72,14 +72,14 @@ Highlights on the same machine:
 > [!tip]
 > DuckDB doesn’t just start fast—it’s getting faster with each release.
 
-## 3. DuckDB SQL Superpowers
+## DuckDB SQL Superpowers
 
 DuckDB’s speed is impressive, but its **SQL dialect is equally modern and friendly**. It adds features that make queries more concise, more powerful, and often easier to read than in traditional systems like PostgreSQL or Spark SQL. Many of these enhancements are captured in the official blog post <FancyLink linkText="Friendlier SQL for DuckDB" url="https://duckdb.org/2022/05/04/friendlier-sql.html" dark="true"/> and in the docs <FancyLink linkText="Friendly SQL | DuckDB docs" url="https://duckdb.org/docs/stable/sql/dialect/friendly_sql.html" dark="true"/>.
 
 > [!note]
 > DuckDB extends SQL in small but thoughtful ways: less boilerplate, more readability.
 
-### 3.1. Extended SQL syntax
+### Extended SQL syntax
 
 * **Select all `except` or `replace` some columns:**
 
@@ -135,7 +135,7 @@ DuckDB allows trailing commas in SELECT lists, GROUP BY, etc.—a small detail t
 > [!tip]
 > Once you’ve used `EXCLUDE`, `REPLACE`, or `GROUP BY ALL`, going back to standard SQL feels unnecessarily verbose.
 
-### 3.2. Built-in functions for analytics
+### Built-in functions for analytics
 
 * **Window functions with QUALIFY:**
 
@@ -199,11 +199,11 @@ This extracts capture groups into columns directly.
 > [!tip]
 > Many tasks that would take subqueries or UDFs elsewhere become one-liners in DuckDB.
 
-## 4. Practical Examples
+## Practical Examples
 
 DuckDB shines when put to work in everyday scenarios. Here are a few concrete ways it adds value.
 
-### 4.1. Exploring data locally
+### Exploring data locally
 
 Need to inspect a Parquet, CSV, or even JSON file? With DuckDB you can query it directly:
 
@@ -232,7 +232,7 @@ DuckDB also lets you `ATTACH` multiple databases or files, so you can explore Pa
 > [!note]
 > DuckDB turns local files into queryable tables instantly—great for quick exploration.
 
-### 4.2. Acting as a data mover
+### Acting as a data mover
 
 DuckDB can serve as a **bridge** between systems, often in a single SQL statement.
 
@@ -259,7 +259,7 @@ This makes DuckDB a handy connector when you just want to move or combine data e
 > [!tip]
 > DuckDB doubles as a lightweight ETL tool: move data between systems or join across them with one query.
 
-### 4.3. Data transformation
+### Data transformation
 
 DuckDB isn’t limited to querying data, it can also be used for heavy-duty transformations like converting formats or casting columns at scale. Because it can stream data efficiently and leverage parallelism, it’s surprisingly effective for one-off ETL tasks.
 
@@ -278,7 +278,7 @@ This makes it trivial to clean up types, normalize strings, or restructure data 
 > In one real-world case, DuckDB ingested and transformed a **75 GB CSV (≈897M rows)** into Parquet on modest hardware, something that failed with other tools. Source: <FancyLink linkText="75 GB CSV ingestion with DuckDB" url="https://www.reddit.com/r/dataengineering/comments/1mxgerm/problems_trying_to_ingest_75_gb_yes_gigabyte_csv/"/>
 
 
-### 4.4. Using DuckDB in CI pipelines with dbt
+### Using DuckDB in CI pipelines with dbt
 
 DuckDB is a fantastic choice for **testing transformations locally or in CI**. Instead of paying for a cloud warehouse, you can spin up DuckDB in GitHub Actions (or any CI runner) and validate logic:
 
@@ -288,7 +288,7 @@ dbt run --target duckdb
 
 This approach is **fast, cheap, and isolated**, making it easy to catch issues early. You can read more about it at <FancyLink linkText="dbt testing with DuckDB" url="https://villoro.com/blog/dbt-testing-duckdb/" dark="true"/>.
 
-### 4.5. Interactive analysis in notebooks
+### Interactive analysis in notebooks
 
 DuckDB isn’t just for the CLI. It integrates seamlessly with Python and R notebooks:
 
@@ -304,11 +304,11 @@ res = duckdb.sql("SELECT * FROM df EXCLUDE(unnecessary_col) WHERE value > 100").
 
 This combination means you can use Pandas/Polars for light data wrangling and DuckDB’s SQL for heavy lifting—all without leaving your notebook.
 
-## 5. DuckLake: A Young but Promising Idea
+## DuckLake: A Young but Promising Idea
 
 DuckDB is already powerful on its own, but the community is pushing it further. One notable experiment is **DuckLake**, an emerging open table format and extension that adds full “lakehouse” capabilities on top of DuckDB. The goal is to combine DuckDB’s simplicity with the robust features of a data lakehouse – bringing in ACID transactions, time travel, schema evolution, and more, without the usual complexity of big-data frameworks.
 
-### 5.1. The concept of bringing lakehouse features into DuckDB
+### The concept of bringing lakehouse features into DuckDB
 
 Traditional lakehouse formats like <FancyLink linkText="Apache Iceberg" url="https://iceberg.apache.org/" company="iceberg"/> and <FancyLink linkText="Delta Lake" url="https://delta.io/"/> manage metadata as **files** (logs, snapshots, schemas) in cloud storage. This avoids a centralized service, but comes at a cost: frequent updates create a flood of small metadata files. In some workloads, metadata grows faster than data itself, leading to slow queries and heavy maintenance.
 
@@ -320,7 +320,7 @@ Traditional lakehouse formats like <FancyLink linkText="Apache Iceberg" url="htt
 
 The idea isn’t without precedent: cloud warehouses like BigQuery and Snowflake also use dedicated databases internally for metadata. DuckLake applies the same principle while keeping the data itself in open Parquet files. It’s a hybrid model: open storage for data, database‑backed catalogs for metadata.
 
-### 5.2. Current state and potential
+### Current state and potential
 
 DuckLake is still early, released as an **experimental DuckDB extension** (since v1.3.0). You can already create DuckLake tables backed by Parquet files on S3 or local storage, with metadata stored in DuckDB itself or an external database like Postgres. This brings features such as:
 

--- a/src/content/blog/0062-ecs.mdx
+++ b/src/content/blog/0062-ecs.mdx
@@ -10,7 +10,7 @@ tags: [AWS, ECS, Docker, uv, DE, Fargate]
 draft: false
 ---
 
-## 0. Why Another ECS Setup?
+## Why Another ECS Setup?
 
 Running Python on ECS is easy until **cold starts** and **rebuild churn** show up. On Fargate every task pulls the image from scratch; when your image includes big dependencies, startup time balloons and short‑lived jobs pay that cost on every run.
 
@@ -19,11 +19,11 @@ Running Python on ECS is easy until **cold starts** and **rebuild churn** show u
 > [!note]
 > This keeps startup fast and behavior consistent across versions—no image rebuilds just to try a change, no dependency drift between runs.
 
-## 1. The Strategy
+## The Strategy
 
 Run **small images** and **fetch the environment at runtime**. This plays to Fargate’s strengths (ephemeral tasks) and avoids paying the cold‑start penalty of large image pulls **every single run**.
 
-### 1.0. What Fargate Optimizes For
+### What Fargate Optimizes For
 
 * **No layer cache between tasks** → each task **pulls the full image** again.
 * **Pull time scales with image size** → big images = slow starts.
@@ -32,7 +32,7 @@ Run **small images** and **fetch the environment at runtime**. This plays to Far
 > [!tip]
 > Keep the image lean; move heavy Python deps out of the image. Treat S3 like a `layer store` for your virtualenv.
 
-### 1.1. Two Approaches (and why one wins on Fargate)
+### Two Approaches (and why one wins on Fargate)
 
 | Approach                                     | What it means                                                | Pros                                                                                                        | Cons                                                                    |
 | -------------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
@@ -42,7 +42,7 @@ Run **small images** and **fetch the environment at runtime**. This plays to Far
 > [!tip]
 > For short‑lived/batch tasks, **B** consistently starts faster: pull a ~80–100 MB image, then download a compressed venv from S3. Net startup is typically **tens of seconds**, not minutes.
 
-### 1.2. The Pattern I Use (and this post documents)
+### The Pattern I Use (and this post documents)
 
 **One image, many jobs/versions.** The Docker image is generic and reusable. The `version` you pass selects what to run.
 
@@ -65,7 +65,7 @@ Run **small images** and **fetch the environment at runtime**. This plays to Far
 > [!tip]
 > Developers can iterate fast: compile a custom version, upload the four artifacts, and run it in prod with `-v <version>` with **no image rebuilds**. Roll forward/back by switching only the version.
 
-### 1.3. Files & Layout
+### Files & Layout
 
 ```plaintext
 deploy/
@@ -83,11 +83,11 @@ tests/
 > [!note]
 > Venv tarballs and lockfiles are **versioned** (e.g., `uv`, `0.7.1`). Run any version in prod with `-v <version>` which is great for hotfixes and A/B verification.
 
-## 2. Building venv and Publishing
+## Building venv and Publishing
 
 We use **`uv`** for speed and determinism: it resolves from a lock file (`uv.lock`), creates a clean in-project venv, installs **our code**, and then packages everything for production. The resulting `venv_<version>.tar.gz` is fully self-contained and versioned for autonomous deployment.
 
-### 2.1 Why two base images (uv + python)?
+### Why two base images (uv + python)?
 
 * **`ghcr.io/astral-sh/uv` stage (distroless)** → provides only the `uv` and `uvx` binaries. We *copy* them in, avoiding `curl`/`apt` installations and keeping the surface minimal.
 * **`python:3.12-slim-bookworm` builder** → provides a small Debian-based runtime with GNU `tar` and `gzip` for packaging. It’s slim, reproducible, and doesn’t need build tools.
@@ -95,7 +95,7 @@ We use **`uv`** for speed and determinism: it resolves from a lock file (`uv.loc
 > [!note]
 > Copying the `uv` binaries (instead of installing them dynamically) keeps the image **small**, **stable**, and **hermetic**. The Python slim base is used solely to build and compress the venv.
 
-### 2.2 Make the venv self-contained
+### Make the venv self-contained
 
 In addition to third-party dependencies, we **install `ecs_northius` into the venv** (non-editable). This means the `venv_<version>.tar.gz` already contains our package and can execute jobs directly in ECS.
 
@@ -105,7 +105,7 @@ In addition to third-party dependencies, we **install `ecs_northius` into the ve
 There are **two valid ways** to make your code importable in the venv.
 Both work but the **pyproject-driven approach** is usually better because it also lets you include non-Python assets (YAML, templates, etc.).
 
-#### 2.2.1 Option A — Classic packages (add `__init__.py`)
+#### Option A — Classic packages (add `__init__.py`)
 
 Add `__init__.py` to every package directory you want importable. Simple and explicit.
 
@@ -123,7 +123,7 @@ where = ["."]
 include = ["ecs_northius*"]
 ```
 
-#### 2.2.2. Option B — Pyproject-driven (recommended)
+#### Option B — Pyproject-driven (recommended)
 
 Skip `__init__.py` by using **namespace packages** (PEP 420) or keep them if you prefer — the key is that discovery and data inclusion are driven by `pyproject.toml`.
 
@@ -158,7 +158,7 @@ ecs_northius = [
 
 > With Option B you can manage both discovery **and** non-Python assets from one place.
 
-### 2.3 Dockerfile.venv
+### Dockerfile.venv
 
 <TerminalOutput color="stone">
   `deploy/docker/Dockerfile.venv`
@@ -222,7 +222,7 @@ docker build -f deploy/docker/Dockerfile.venv --output . . --build-arg PACKAGE_V
 > [!note]
 > The resulting `venv_0.1.0.tar.gz` is portable — upload it to S3 and reuse it across ECS tasks.
 
-### 2.4 Extra optimizations & tricks
+### Extra optimizations & tricks
 
 * **`.dockerignore` aggressively**: exclude `.git`, `tests/`, build artifacts, local caches. Smaller build context = faster.
 * **Cache-friendly layering**: copy `pyproject.toml` + `uv.lock` before project sources to maximize `uv sync` cache hits.
@@ -233,7 +233,7 @@ docker build -f deploy/docker/Dockerfile.venv --output . . --build-arg PACKAGE_V
 > [!warning]
 > Avoid compilers and build tools unless you need to compile native deps. Prefer prebuilt manylinux wheels for portability.
 
-### 2.5 Publishing the artifacts
+### Publishing the artifacts
 
 Once built, we publish the venv and its companion files to S3. The **`upload_all.py`** script handles this automatically.
 It can also optionally upload the requested version as `latest`.
@@ -294,12 +294,12 @@ if __name__ == "__main__":
 > [!tip]
 > This closes the loop: every artifact is versioned, uploaded, and retrievable by the runtime.
 
-## 3. The Runtime
+## The Runtime
 
 At runtime, **speed and simplicity** take priority; no compilers, no `uv`, no dependency resolution.
 The container just downloads, activates, and executes.
 
-### 3.1 Runtime Image
+### Runtime Image
 
 <TerminalOutput color="stone">
   `deploy/docker/Dockerfile.runtime`
@@ -326,7 +326,7 @@ The size can increase with big libraries such as awswrangler.
 > [!note]
 > The runtime image is lightweight — no compilers, no dependency resolution. It starts quickly and scales efficiently across short-lived ECS tasks.
 
-### 3.2 Runtime Bootstrap Script
+### Runtime Bootstrap Script
 
 Executed automatically when the container starts:
 
@@ -358,7 +358,7 @@ python entrypoint.py "$@"
 > [!note]
 > The bootstrap keeps tasks reproducible and fast — it only fetches what’s needed for the specified version.
 
-### 3.3 Download Script
+### Download Script
 
 This script fetches all necessary artifacts (venv, entrypoint, and config) from S3 and prepares the environment for execution.
 
@@ -418,7 +418,7 @@ if __name__ == "__main__":
 > [!warning]
 > Python 3.14+ tightens tar extraction security — use `filter="fully_trusted"` to avoid `AbsoluteLinkError` when unpacking symlinks.
 
-### 3.4 How this connects to entrypoints & params
+### How this connects to entrypoints & params
 
 This section focuses on **runtime packaging and activation**. For dynamic entrypoints (import-by-string), argument parsing via `click`, and typed params with `pydantic`, see <FancyLink linkText="Effortless EMR: A Guide to Seamlessly Running PySpark Coder" url="https://villoro.com/blog/effortless-emr-guide-running-pyspark/" dark="true"/>.
 The same entrypoint model integrates seamlessly here.
@@ -427,7 +427,7 @@ The same entrypoint model integrates seamlessly here.
 > Because `pyproject`, `uv.lock`, `venv`, and `entrypoint` are versioned together, each run is **fully autonomous** and reproducible.
 > Developers can safely test new jobs in production by uploading a custom version and running it with `-v <version>`.
 
-### 3.5 How It Runs in ECS
+### How It Runs in ECS
 
 Run tasks by passing a version at launch:
 
@@ -444,11 +444,11 @@ At runtime the container:
 > [!note]
 > You can run multiple versions in parallel (for example, `-v latest` for dev and `-v 0.7.1.villoro` for prod) without rebuilding Docker images.
 
-## 4. CI/CD Flow
+## CI/CD Flow
 
 We keep **testing**, **venv publishing**, and **runtime image pushes** as separate jobs. This speeds up iteration (you rarely need to rebuild the runtime docker image) and preserves reproducibility (each venv is versioned).
 
-### 4.1. CI: Tests with `uv`
+### CI: Tests with `uv`
 
 <TerminalOutput color="stone">
   `.github/workflows/CI.yaml`
@@ -486,7 +486,7 @@ jobs:
         run: uv run python -m pytest -q
 ```
 
-### 4.2. CD: Build & Publish venv to S3
+### CD: Build & Publish venv to S3
 
 Triggers when app code, dependency files, or deployment config changes. Produces a **versioned quartet**: `pyproject_<v>.toml`, `uv_<v>.lock`, `entrypoint_<v>.py`, `venv_<v>.tar.gz`.
 
@@ -542,7 +542,7 @@ jobs:
         run: python deploy/scripts/upload_all.py --version $VERSION_CURRENT --latest
 ```
 
-### 4.3. CD: Build & Push the Runtime Image to ECR
+### CD: Build & Push the Runtime Image to ECR
 
 This job changes infrequently (scripts or the runtime Dockerfile). It tags with the version from `pyproject.toml` and with `latest`.
 
@@ -611,21 +611,21 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 ```
 
-### 4.4. Deployment workflow summary:
+### Deployment workflow summary:
 
 1. **CI** runs tests on every PR as a mandatory step.
 2. On merge to `main`, **CD Venv** builds `venv_<version>.tar.gz` and uploads all versioned artifacts to S3.
 3. **CD Docker** rebuilds and pushes the runtime image to ECR (only if there are changes).
 4. **ECS tasks** start containers using the latest runtime image, fetching the desired venv version dynamically with `-v <version>`.
 
-### 4.5. Practical tips
+### Practical tips
 
 * **Pin Python versions**: keep GitHub Action Python versions aligned with Dockerfiles.
 * **Cache `uv`**: already included; it makes PR validation fast.
 * **S3/ECR VPC endpoints**: set them to avoid NAT costs in private subnets.
 * **Immutable versions + `latest`**: publish both; production can point at `latest` while you can roll forward/back with a version flag.
 
-## 5. Wrapping Up
+## Wrapping Up
 
 You now have a **fast, versioned, and reproducible** pattern for running Python on ECS:
 

--- a/src/content/blog/0063-monorepo_multimage.mdx
+++ b/src/content/blog/0063-monorepo_multimage.mdx
@@ -10,7 +10,7 @@ tags: [AWS, ECS, Docker, uv, DE, Fargate, Monorepo]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 Every project starts small. In our case, it was a straightforward ELT setup focused on extracting data from APIs and storing it cleanly. At the time, we didn’t need a complex monorepo—just a single workspace with a small set of interdependent packages.
 
@@ -18,7 +18,7 @@ As the team grew and the project evolved to cover more diverse domains (scraping
 
 This post explains how we made that evolution: from a single-package workspace to a scalable, cleanly isolated monorepo with CI/CD tailored for each package.
 
-## 1. Monorepo Design Options
+## Monorepo Design Options
 
 When you start a Python monorepo, you typically have two options:
 
@@ -27,7 +27,7 @@ When you start a Python monorepo, you typically have two options:
 
 Let’s look at each.
 
-### 1.1 Single Workspace: Easy at First
+### Single Workspace: Easy at First
 
 > [!note]
 > This is a great starting point. It keeps things simple while you're focused on building a single flow or service.
@@ -42,7 +42,7 @@ This is the setup described in <FancyLink linkText="Fast and Reproducible Python
 
 But as the codebase expands to include APIs, ML pipelines, or connectors, the single workspace model starts to break down—dependency conflicts emerge (e.g., `prefect` needing `package_x<3` while `pandas` needs `package_x>=4`), and even simple jobs end up dragging massive venvs due to heavyweight libraries.
 
-### 1.2 Multi-Workspace: Scales Better
+### Multi-Workspace: Scales Better
 
 When packages become logically independent (e.g. `nt_sdk`, `nt_rds`, `nt_ml`), a multi-workspace monorepo makes more sense:
 
@@ -63,7 +63,7 @@ src/
 
 In the next section, we’ll explain the benefits in more detail and how we organized the transition.
 
-## 2. Monorepo with Multiple Workspaces
+## Monorepo with Multiple Workspaces
 
 When splitting a growing project into independent parts, the first challenge is organizing the codebase.
 
@@ -93,7 +93,7 @@ Each top-level folder inside `src/` represents a standalone package with its own
 > [!note]
 > While it’s possible to have a single workspace that includes all packages, using independent workspaces provides better isolation, easier testing, and faster deployment for modular systems.
 
-### 2.1 Creating Shared Code with `nt_common`
+### Creating Shared Code with `nt_common`
 
 Sometimes, packages need to share common logic—models, helpers, utilities. That’s where `nt_common` comes in. It behaves like any other package but is added as a local dependency to others.
 
@@ -112,7 +112,7 @@ This installs `nt_common` as a **built wheel**, with its pinned dependencies fro
 > [!note]
 > If you update `nt_common`, run `uv sync` in the dependent package (e.g., `nt_api`) to apply the latest version.
 
-### 2.2 Minimal `pyproject.toml` example
+### Minimal `pyproject.toml` example
 
 Here's a clean example for `nt_api`:
 
@@ -157,13 +157,13 @@ Key points:
 * `package-data` makes sure config files are bundled
 * `pytest` under `dev` allows for easy testing without affecting prod dependencies
 
-## 3. Import Testing in CI
+## Import Testing in CI
 
 To guarantee correctness before packaging or deploying any Python package, we include a minimal test that confirms all modules can be imported. This prevents common issues such as missing dependencies, misconfigured paths, or broken module declarations.
 
 This test runs as part of every pull request and is required to pass before merge. It's fast and effective at catching mistakes early.
 
-### 3.1. How It Works
+### How It Works
 
 We use `pytest` and `importlib` to:
 
@@ -173,7 +173,7 @@ We use `pytest` and `importlib` to:
 
 This ensures the codebase reflects the dependencies declared in `pyproject.toml`, and any structural issues are caught early.
 
-### 3.2. Minimal Test Code
+### Minimal Test Code
 
 <TerminalOutput color="stone">
   `src/nt_xxx/tests/test_imports.py`
@@ -208,11 +208,11 @@ def test_import_module(module_name):
 
 This will be placed in each package and tested at each PR.
 
-## 4. CI/CD with Matrix Strategy
+## CI/CD with Matrix Strategy
 
 To keep packages isolated but uniformly tested, we use GitHub Actions with a matrix job. This approach scales easily as new packages are added by just updating the matrix list.
 
-### 4.1 Matrix Setup for Pytest
+### Matrix Setup for Pytest
 
 We use a shared CI workflow that:
 
@@ -239,7 +239,7 @@ strategy:
 
 You can read more about this at <FancyLink linkText="Scalable GitHub Actions for Modern Repos" url="https://villoro.com/blog/github-hooks/" dark="true"/>.
 
-### 4.2 Generic `Dockerfile.venv`
+### Generic `Dockerfile.venv`
 
 To build reproducible, isolated environments for each package, we use a shared `Dockerfile.venv`:
 
@@ -259,7 +259,7 @@ Or optionally, structured by folder:
 nt_api/venv_0.3.1.tar.gz
 ```
 
-### 4.3 Uploading and Referencing Artifacts
+### Uploading and Referencing Artifacts
 
 Because each package produces its own archive, downstream systems (e.g., deployment scripts or S3 uploads) must:
 
@@ -270,7 +270,7 @@ This makes it trivial to deploy or cache specific venvs for small jobs, without 
 
 Ensure your `upload_all.py` or similar code respects the naming convention so each file is easy to find and consume.
 
-## 5. Closing Thoughts
+## Closing Thoughts
 
 Starting with a single workspace and a simple `uv`-based setup (as shown in <FancyLink linkText="Fast and Reproducible Python Deployments on ECS with uv" url="https://villoro.com/blog/fast-python-ecs-with-uv/" dark="true"/>) is the most efficient way to bootstrap a project. It keeps complexity low and lets you move fast.
 

--- a/src/content/blog/0064-github_hooks.mdx
+++ b/src/content/blog/0064-github_hooks.mdx
@@ -10,15 +10,15 @@ tags: [CI/CD, GitHub, Python, Best Practices, Monorepo]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 Creating maintainable and efficient GitHub Actions pipelines becomes critical when you manage multiple repositories or modular projects. This post walks through four key patterns to make your CI/CD setup scalable, reliable, and fast.
 
-## 1. Reusable Hooks Across Repositories
+## Reusable Hooks Across Repositories
 
 When multiple repositories share CI logic, extract it into a reusable **composite action** that lives in a dedicated repo (e.g., `villoro/vhooks`). This pattern keeps your CI/CD logic consistent across projects while avoiding duplication.
 
-### 1.1 Repository Layout
+### Repository Layout
 
 Start by organizing your hooks into separate folders, each representing a single reusable action.
 
@@ -37,7 +37,7 @@ vhooks/
 > [!note]
 > Each folder under `vhooks` is a standalone hook. The `action.yml` defines its interface, while the Python file contains the logic.
 
-### 1.2 Composite Action Definition
+### Composite Action Definition
 
 The composite action serves as the glue between GitHub Actions and your Python script. It defines the inputs, runs any required setup, and calls your Python logic.
 
@@ -120,7 +120,7 @@ runs:
           })
 ```
 
-### 1.3 Python Implementation
+### Python Implementation
 
 The Python script extracts the version from your file and pushes a new tag if it doesn’t exist yet.
 
@@ -182,7 +182,7 @@ if __name__ == "__main__":
     main()
 ```
 
-### 1.4 Consuming the Hook from Any Repo
+### Consuming the Hook from Any Repo
 
 To use your new hook, create a simple workflow that triggers on `main` pushes and automatically tags new versions.
 
@@ -208,11 +208,11 @@ jobs:
 > [!tip]
 > Always pin to a version tag like `@1.3.0` to avoid breaking changes from `main`.
 
-## 2. Matrix Jobs
+## Matrix Jobs
 
 Matrix jobs let you apply the same logic across multiple packages without duplicating YAML. Keep the matrix minimal (only what varies), derive everything else at runtime, and filter work so each package runs only when its files change.
 
-### 2.1 Minimal Matrix, Clear Names
+### Minimal Matrix, Clear Names
 
 Only include the fields you truly need (here: `name` and `tag_prefix`). Everything else (paths, tags) is computed per package.
 
@@ -266,7 +266,7 @@ jobs:
 > [!note]
 > The hook receives a different `file` and `tag-prefix` per package. `dorny/paths-filter` inside the hook ensures we only tag when that package actually changed.
 
-### 2.2 Practical Tips
+### Practical Tips
 
 * Use `strategy.fail-fast: false` so one failure doesn’t cancel all packages.
 * Keep job names informative (e.g., `tag / nt_api`).
@@ -275,11 +275,11 @@ jobs:
 > [!tip]
 > Minimal matrices + in‑hook filtering = fast runs and clean YAML as your monorepo grows.
 
-## 3. Gate Jobs
+## Gate Jobs
 
 Branch protection becomes noisy if you require every matrix job. Add a gate job that depends on the matrix and fails if any package failed and then protect only the gate.
 
-### 3.1 Aggregate Matrix Results
+### Aggregate Matrix Results
 
 Create a tiny job that always runs, inspects the matrix result, and exits accordingly.
 
@@ -309,7 +309,7 @@ Create a tiny job that always runs, inspects the matrix result, and exits accord
 > **Common Pitfall:** Expressions like `${{ hashFiles() }}` don’t evaluate inside the matrix definition.
 > Compute cache keys at runtime instead using values like `matrix.name` or `matrix.path` inside a step.
 
-## 4. Concurrency
+## Concurrency
 
 When you push new commits to a PR, older runs become obsolete. Cancel them automatically to save resources.
 
@@ -335,7 +335,7 @@ jobs:
 
 This ensures that only the latest workflow for each PR remains active.
 
-## 5. Putting It All Together
+## Putting It All Together
 
 Reusable hooks, matrix jobs, gate checks, and concurrency form a **scalable CI/CD pattern**:
 

--- a/src/content/blog/0065-protecting-prod-tables.mdx
+++ b/src/content/blog/0065-protecting-prod-tables.mdx
@@ -10,7 +10,7 @@ tags: [dbt, SQL, DE]
 draft: false
 ---
 
-## 1. Ways of Protecting Production Tables
+## Ways of Protecting Production Tables
 
 Production tables are the backbone of any data platform. They feed dashboards, power APIs, and sometimes even trigger external actions (like sending emails or pushing updates to third-party systems).
 
@@ -20,7 +20,7 @@ Because of this, mistakes in production tables can quickly escalate into costly 
 2. Protecting against unexpected changes.
 3. Protecting sensitive data.
 
-## 2. Protecting Against Bad Data
+## Protecting Against Bad Data
 
 The idea is simple:
 
@@ -38,7 +38,7 @@ For example, if a table is used to trigger customer emails, it’s safer to dela
 > This pattern is not for every model. Use it sparingly — only when data quality is more important than timeliness.
 
 
-## 3. Protecting Against Unexpected Changes
+## Protecting Against Unexpected Changes
 
 Sometimes the main risk isn’t bad data, but unintentional modifications. A small schema tweak or row-level difference can trigger expensive or disruptive actions downstream (like syncing thousands of rows into Salesforce).
 
@@ -178,7 +178,7 @@ SELECT * FROM data_diff
 > [!note]
 > This adds a small PR overhead, but it prevents costly mistakes in production syncs and batch jobs.
 
-## 4. Protecting Sensitive Data
+## Protecting Sensitive Data
 
 Finally, some tables are too sensitive to expose — like payroll data. Access should be restricted to a small subset of users.
 
@@ -272,7 +272,7 @@ It’s important that the **seed schema matches the real source schema**. One wa
 > [!tip]
 > With this pattern, developers can test pipelines safely while production runs always use real data.
 
-## 5. Summary and Best Practices
+## Summary and Best Practices
 
 * **Bad data protection**: prioritize data quality over freshness. Use for critical tables powering user-facing actions.
 * **Unexpected changes**: catch unintended diffs before merging. Ideal for tables that trigger expensive syncs or updates.

--- a/src/content/blog/0066-recover_s3_files.mdx
+++ b/src/content/blog/0066-recover_s3_files.mdx
@@ -10,11 +10,11 @@ tags: [DE, AWS, S3, Python, Best Practices, Versioning]
 draft: false
 ---
 
-## 0. Intro
+## Intro
 
 APIs and data lakes are unforgiving: one wrong path and you can “delete” an entire table. This post shows exactly how we recovered **Iceberg tables deleted by mistake** by leveraging **S3 Versioning** and **delete markers**, with a notebook‑friendly pandas workflow.
 
-## 1. What happened
+## What happened
 
 > [!warning]
 > If your buckets aren’t versioned, stop and enable Versioning before anything else. Without it, you’ll need backups/replication or CloudTrail logs to reconstruct keys.
@@ -42,11 +42,11 @@ Because we use **Iceberg tables**, recovering the wrong files could break table 
 
 Fortunately, all S3 deletions are logged, and our buckets had **versioning and delete markers enabled**, letting us precisely identify the deletion window and safely restore the affected files.
 
-## 2. S3 Versioning
+## S3 Versioning
 
 When working with critical datasets like Iceberg tables, **S3 Versioning is your safety net**. It allows you to recover any object or undo accidental deletions by maintaining historical versions of every file.
 
-### 2.1. Why it matters
+### Why it matters
 
 Versioning ensures that every modification or deletion is reversible:
 
@@ -59,7 +59,7 @@ This behavior protects you from accidents like mass deletions, misconfigured pat
 > [!note]
 > When versioning is enabled, you can roll back changes at the object level — essential for recovering partitioned Iceberg tables where structure and data must stay consistent.
 
-### 2.2. How to enable versioning
+### How to enable versioning
 
 You can enable versioning on any S3 bucket through the AWS Console or CLI:
 
@@ -76,7 +76,7 @@ aws s3api put-bucket-versioning \
 
 For more details, see the <FancyLink linkText="S3 Versioning | AWS docs" url="https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html" company="aws"/>.
 
-### 2.3. Recommended practices
+### Recommended practices
 
 * **Lifecycle policies:** Automatically clean up older versions after a defined retention period to manage costs.
 * **MFA Delete:** Add an extra confirmation layer for deletions (useful for production or critical buckets).
@@ -85,7 +85,7 @@ For more details, see the <FancyLink linkText="S3 Versioning | AWS docs" url="ht
 > [!warning]
 > Versioning only protects files **after** it’s enabled. Enable it early before something goes wrong.
 
-## 3. How Delete Markers Work
+## How Delete Markers Work
 
 When S3 versioning is enabled, deleting an object doesn’t actually remove its data. Instead, AWS adds a **delete marker** which is a special placeholder that marks the object as deleted while keeping all its previous versions safely stored.
 
@@ -125,11 +125,11 @@ Removing `v4` restores `v2` (the most recent data version). Removing `v3` change
 > [!warning]
 > If versioning is disabled or suspended, delete markers may behave differently. Ensure versioning was active when the deletion happened.
 
-## 4. Our Recovery Strategy
+## Our Recovery Strategy
 
 After confirming versioning was enabled, the goal was to **recover only the files deleted during the incident window** — not everything that had ever changed. Recovering too much could break Iceberg table consistency, so precision was essential.
 
-### 4.1. Steps we followed
+### Steps we followed
 
 1. **Identify the time window** of the incident
    * We used Prefect logs to pinpoint exactly when the erroneous delete ran.
@@ -151,7 +151,7 @@ After confirming versioning was enabled, the goal was to **recover only the file
 > [!note]
 > Restoring a file means deleting its delete marker. We filtered strictly by the incident timestamps to ensure that only the files deleted by mistake were brought back.
 
-## 5. Investigate delete markers
+## Investigate delete markers
 
 Before restoring anything, we first **enumerate all delete markers** for a given prefix and filter them to the exact incident window.
 This gives us a clear, auditable list of what would be restored.
@@ -226,7 +226,7 @@ def scan_delete_markers(s3, bucket, prefix, start_ts, end_ts):
 > [!note]
 > The scan collects rows first, then vectorizes timestamp casting and eligibility — faster and simpler than per‑row logic.
 
-## 6. Actually recovering files
+## Actually recovering files
 
 Now that we have an audited list of delete markers, we restore by **deleting those markers**. Start with a dry‑run to validate scope, then apply in batches.
 
@@ -294,11 +294,11 @@ def recover_s3_delete_markers(bucket, prefix, start_ts, end_ts, dry_run=True, ex
     return df
 ```
 
-## 7. Conclusion
+## Conclusion
 
 Recovering the Iceberg tables wasn’t about luck, it was about preparation. Versioning gave us a rewind button, and precise recovery logic kept metadata and data aligned.
 
-### 7.1. Key lessons
+### Key lessons
 
 * Always isolate table paths — no shared prefixes.
 * Keep S3 versioning **enabled** across all critical buckets.

--- a/src/content/blog/0067-marimo-notebooks.mdx
+++ b/src/content/blog/0067-marimo-notebooks.mdx
@@ -13,13 +13,13 @@ draft: false
 import marimoUi from "../../images/posts/2026/0067-marimo-ui.png";
 import marimoRecoverS3 from "../../images/posts/2026/0067-marimo-recover-s3-files.png";
 
-## 0. Intro
+## Intro
 
 I have used Jupyter notebooks for years, and recently I started trying <FancyLink linkText="marimo" url="https://marimo.io/"/>.
 
 In this post I want to explain why I think it is a very interesting alternative for Python projects, and then show one small example at the end.
 
-## 1. Marimo as a Jupyter alternative
+## Marimo as a Jupyter alternative
 
 I still think Jupyter notebooks are very useful.
 For quick exploration, ad-hoc analysis, or testing an idea, they are hard to beat.
@@ -56,7 +56,7 @@ It is Python code that happens to render as a notebook.
 So I do not really see marimo as "Jupyter but nicer".
 I see it more as a notebook tool for the cases where the notebook is slowly becoming part of the project itself.
 
-## 2. Execution order, reloading, and variable redefinition
+## Execution order, reloading, and variable redefinition
 
 This is the part I liked the most.
 
@@ -124,7 +124,7 @@ It forces a cleaner structure, and that makes the notebook easier to understand 
 > The nice part is not only that the notebook updates automatically.
 > It is that the update follows the dependencies between cells, so the notebook behaves more like a DAG than like a mutable scratchpad.
 
-## 3. Why being a plain Python file matters
+## Why being a plain Python file matters
 
 This is another big reason I like it.
 
@@ -173,7 +173,7 @@ The nice part is that there is no special format involved here, just regular Pyt
 And I think that matters a lot.
 If a notebook is useful enough to keep, then it is useful enough to deserve clean diffs and normal code review.
 
-## 4. UI elements
+## UI elements
 
 Marimo has quite a few useful UI elements:
 
@@ -234,7 +234,7 @@ Without them, the widgets can end up feeling scattered.
 > [!note]
 > This is enough to turn a notebook into a small internal tool without leaving Python.
 
-## 5. SQL integration and plotting
+## SQL integration and plotting
 
 This is another area where marimo is stronger than I expected.
 
@@ -267,7 +267,7 @@ So for data exploration, the combination is very nice:
 > [!note]
 > I think this is one of the strongest parts of marimo for data work: SQL and plots are not bolted on, they fit naturally into the same reactive workflow.
 
-## 6. A real example: recovering deleted S3 files
+## A real example: recovering deleted S3 files
 
 One example I like a lot is a marimo notebook I built for recovering deleted S3 files.
 I already explained the underlying recovery logic in <FancyLink linkText="Recover deleted S3 files with delete markers" url="https://villoro.com/blog/recover-s3-files-delete-markers/" dark="true"/>, so here I only want to focus on why marimo is a good fit for the interface.
@@ -360,7 +360,7 @@ I like this example because it combines most of the things I mentioned before:
 
 And I think this is exactly the kind of workflow where marimo makes a lot of sense.
 
-## 7. Closing thoughts
+## Closing thoughts
 
 Marimo gets a lot of small things right:
 

--- a/src/content/blog/9999-one-environment-prod.mdx
+++ b/src/content/blog/9999-one-environment-prod.mdx
@@ -10,9 +10,9 @@ tags: [Python, dbt, DE, Environments]
 draft: true
 ---
 
-## 1. Why multiple environments exist
+## Why multiple environments exist
 
-### 1.1 The traditional setup: dev, test, sandbox, prod
+### The traditional setup: dev, test, sandbox, prod
 
 In software and data engineering, it’s common to separate work into multiple environments. Code is built in **dev**, validated in **test/staging**, sometimes explored in a **sandbox**, and only then deployed to **prod**. The idea is simple: keep experiments and errors away from the systems that matter.
 
@@ -20,7 +20,7 @@ In software and data engineering, it’s common to separate work into multiple e
 
 This layering reduces risk by catching problems earlier and isolating them from production.
 
-### 1.2 What problems they try to solve
+### What problems they try to solve
 
 Multiple environments exist to:
 
@@ -33,9 +33,9 @@ Multiple environments exist to:
 > [!note]
 > More environments mean more guardrails before code reaches production.
 
-## 2. The dbt perspective
+## The dbt perspective
 
-### 2.1 How dbt handles environments
+### How dbt handles environments
 
 In dbt, environments live in the `profiles.yml`. Each profile contains one or more **targets** that describe how dbt should connect: warehouse, database, schema, and credentials. This design means your project code doesn’t change — dbt simply decides *where* to build models based on the target.
 
@@ -46,7 +46,7 @@ The important piece is how dbt uses **database/schema naming conventions**. Inst
 
 This allows everyone to work against the same production data and warehouse while keeping outputs separated. Developers can safely test changes in their own prefixed schemas without touching production tables.
 
-### 2.2 Switching targets with profiles
+### Switching targets with profiles
 
 Profiles make it easy to switch between these targets. By default, a developer might run dbt with a personal target, which builds into `villoro_salesforce`. When deploying, the pipeline switches to the `prod` target, which builds into `prod_salesforce`. You can read more about it at <FancyLink linkText="dbt | Understanding custom schemas" url="https://docs.getdbt.com/docs/build/custom-schemas#understanding-custom-schemas"/>.
 
@@ -55,17 +55,17 @@ Profiles make it easy to switch between these targets. By default, a developer m
 
 Both environments use the same underlying warehouse and data, so development runs closely mimic production. The only difference is the schema prefix — `prod_` for production, `<user>_` for development. This convention ensures realistic testing, strict protection of production outputs, and seamless promotion from personal work to production.
 
-## 3. One environment to rule them all
+## One environment to rule them all
 
 The same idea can be applied outside of dbt. In Python projects, you can also run everything on production infrastructure while keeping outputs isolated.
 
-### 3.1 How to make it safe
+### How to make it safe
 
 * **Schema prefixes** – follow the same pattern as dbt: `prod_salesforce` for production, `villoro_salesforce` for a dev run. Everyone shares the same data and compute, but results go into different schemas.
 * **Environment variables** – control the prefix with an `ENV` or `SCHEMA_PREFIX` variable. Pipelines stay identical; only the destination changes.
 * **Permissions** – block developers from writing to `prod_` schemas. Even if someone misconfigures, they can’t damage production tables.
 
-### 3.2 Dealing with side effects
+### Dealing with side effects
 
 Code often does more than write tables: send emails, call APIs, trigger dashboards. These actions can be dangerous in a prod-only setup.
 
@@ -83,7 +83,7 @@ else:
 
 The same trick applies to API calls, data deletions, or notifications.
 
-### 3.3 Patterns in practice
+### Patterns in practice
 
 Many teams use this approach:
 
@@ -93,16 +93,16 @@ Many teams use this approach:
 
 ![dbt custom schemas](../../images/posts/2025/9999-dbt-custom-schemas.jpg)
 
-## 4. Pros and cons
+## Pros and cons
 
-### 4.1 Advantages: simplicity, less drift, fewer surprises
+### Advantages: simplicity, less drift, fewer surprises
 
 * **Less infra** – only one environment to manage.
 * **No drift** – everyone works in the same place, no mismatched configs.
 * **Realistic dev** – you test against real data and prod-like conditions.
 * **Faster cycle** – no need to promote across multiple stages.
 
-### 4.2 Risks: less safe experimentation, higher blast radius
+### Risks: less safe experimentation, higher blast radius
 
 * **Unsafe tests** – mistakes can impact prod data if not isolated.
 * **Bigger blast radius** – a bad query or heavy job can hurt live workloads.
@@ -112,7 +112,7 @@ Many teams use this approach:
 > [!danger]
 > The main risk of prod-only is a **higher blast radius** — one mistake can affect critical data or workloads.
 
-### 4.3 Mitigation strategies
+### Mitigation strategies
 
 * **Schema prefixes** – `prod_salesforce` for prod, `villoro_salesforce` for dev.
 * **Permissions** – devs can’t write to `prod_` schemas.
@@ -122,15 +122,15 @@ Many teams use this approach:
 > [!tip]
 > Combining schema isolation, strict permissions, and feature toggles gives most of the safety of multi-env setups, without the overhead.
 
-## 5. Closing thoughts
+## Closing thoughts
 
-### 5.1 When it makes sense to go prod-only
+### When it makes sense to go prod-only
 
 * Small teams that can coordinate easily.
 * Mature pipelines with solid tests and monitoring.
 * When cost and simplicity matter more than strict safety.
 
-### 5.2 When you probably still want multiple environments
+### When you probably still want multiple environments
 
 * Large or complex systems with many users.
 * Workflows tied to external services.

--- a/src/content/blog/9999-qlik-api.mdx
+++ b/src/content/blog/9999-qlik-api.mdx
@@ -10,7 +10,7 @@ tags: [Python, API, Data Engineering, Best Practices]
 draft: true
 ---
 
-## 0. Intro
+## Intro
 
 Most teams meet Qlik Cloud through dashboards, but as a data engineer you eventually need to **automate** it: list apps, harvest metadata, and trigger reloads from your pipelines. Qlik’s API supports async, bulk, and webhooks, but the fastest path to reliable automation is a **small, synchronous client** you understand end-to-end.
 
@@ -24,7 +24,7 @@ This guide builds that client in incremental steps with `requests`, focusing on 
 * Trigger **reloads** and **poll** status until success/failure/timeout
 * Pragmatic **error handling** and retry pointers
 
-## 1. Authentication
+## Authentication
 
 We will create a class because it provides a clean way to encapsulate authentication, session reuse, and default settings. This makes it easier to extend later with helpers for pagination, reloads, and metadata.
 
@@ -61,7 +61,7 @@ class QlikClient:
 
 Next, we’ll add a safe request helper that wraps `requests` with timeouts, optional retries, and debug-aware error handling.
 
-## 2. `_get` helper
+## `_get` helper
 
 Every client needs a **single choke-point** for read requests. Centralizing GET logic gives you one place to set defaults (headers, timeouts), enforce invariants (pagination limit), and add behavior (debug, retries, logging) without touching call-sites.
 
@@ -108,7 +108,7 @@ Why an internal `_get`:
 > [!note]
 > If you see 400s with boolean query params, try casting them to strings (see the commented line). Some gateways expect `true`/`false` as strings.
 
-## 3. Pagination
+## Pagination
 
 Many Qlik endpoints return a `links.next.href` for the next page. Here’s how to walk them:
 
@@ -155,7 +155,7 @@ Many Qlik endpoints default to returning only 100 items per page so in order to 
 > [!warning]
 > Tune `self.max_calls` to protect your jobs from runaway loops (e.g., if the API keeps returning a next link). Add logging around `i` if you need visibility.
 
-## 4. Custom public methods
+## Custom public methods
 
 Some endpoints need **special treatment** (validation, parameter shaping, friendlier errors). Expose these as **public methods** on your client and keep the one-off logic inside them, while leaving `_get` small and generic.
 
@@ -191,7 +191,7 @@ Why a public method here?
 > [!note]
 > You can reuse `_check_uuid` for other endpoints (e.g., reloads, automations) by passing named arguments: `self._check_uuid(reload_id=reload_id)`.
 
-## 5. Triggering reloads with `_post`
+## Triggering reloads with `_post`
 
 Reloads are submitted with a POST. Qlik returns a `reload_id` you can use to track progress.
 
@@ -237,7 +237,7 @@ Keep `_post` generic just like `_get`. Endpoint-specific quirks (e.g., required 
 > [!note]
 > Qlik often answers with `202 Accepted` for fire-and-forget operations. Returning `{}` from `_post` in that case avoids JSON decode errors and keeps call-sites simple.
 
-## 6. Polling reload status
+## Polling reload status
 
 Reloads may take minutes. You can’t assume they finish instantly, so polling is essential. Below is a simple, sync poller that uses `time.monotonic()` and caps total wait time.
 
@@ -292,7 +292,7 @@ Why polling is necessary
 * A single reload can outlive your HTTP timeout.
 * Polling gives you control over total wait time and backoff cadence.
 
-## 7. Error handling and retries
+## Error handling and retries
 
 Things to watch out for:
 

--- a/src/content/blog/9999-qlik-async.mdx
+++ b/src/content/blog/9999-qlik-async.mdx
@@ -10,13 +10,13 @@ tags: [Python, API, AsyncIO, Data Engineering]
 draft: true
 ---
 
-## 0. Intro
+## Intro
 
 In the previous post (<FancyLink linkText="Querying Qlik API with Python" url="https://villoro.com/blog/querying-qlik-api-python/" dark="true"/>) we built a **synchronous client** for Qlik Cloud. It was simple, debuggable, and covered the basics: auth, pagination, reloads, and retries. But when you start to automate **multiple reloads** or poll **many apps at once**, sync becomes a bottleneck.
 
 With Python’s `asyncio` and `aiohttp`, you can scale to **dozens or hundreds of API calls concurrently**, without threads or processes. This post shows how to rebuild the client with async foundations, keeping the same principles: copy/paste‑ready code, tight surface area, and clear seams for production use.
 
-## 1. Async foundations (with tiny, practical examples)
+## Async foundations (with tiny, practical examples)
 
 Why bother?
 
@@ -25,7 +25,7 @@ Why bother?
 
 Goal: show what async *is* with minimal, standalone snippets. No Qlik yet.
 
-### 1.1 Blocking vs async waiting
+### Blocking vs async waiting
 
 **Blocking**: the loop sleeps *serially*.
 
@@ -58,7 +58,7 @@ asyncio.run(main())
 > [!note]
 > **Idea:** `await` yields control while the task is waiting (I/O, sleep), so other tasks can run.
 
-### 1.2 Async context managers
+### Async context managers
 
 Use `async with` to manage resources (e.g., network sessions, DB connections):
 
@@ -79,7 +79,7 @@ async def main():
 asyncio.run(main())
 ```
 
-### 1.3 Bounded concurrency with a semaphore
+### Bounded concurrency with a semaphore
 
 Limit how many tasks run at once to avoid overwhelming services.
 
@@ -99,7 +99,7 @@ async def main():
 asyncio.run(main())
 ```
 
-### 1.4 Mapping work over inputs (no `while` loops)
+### Mapping work over inputs (no `while` loops)
 
 Create tasks from inputs and collect results.
 
@@ -126,7 +126,7 @@ asyncio.run(main())
 2. Prefer `asyncio.gather` over manual scheduling when you can.
 3. Add a semaphore when calling external services to cap concurrency.
 
-## 2. Rebuilding the client
+## Rebuilding the client
 
 We’ll mirror the sync client, but use async building blocks from Section 1: `async def`, `await`, `async with`, and a semaphore for back‑pressure.
 
@@ -177,7 +177,7 @@ class QlikAsyncClient:
 > [!tip]
 > The semaphore is your safety valve. Start conservative (e.g., 5–10). You can raise it after measuring Qlik tenant limits and your runner’s bandwidth.
 
-## 3. Async GET helper
+## Async GET helper
 
 This mirrors the sync `_get`, but uses `await`, a semaphore, and optional retries. One choke‑point keeps headers, limits, and error handling consistent.
 
@@ -228,7 +228,7 @@ class QlikAsyncClient:
 > [!note]
 > If you hit 400s when sending boolean query params, cast them to strings (`"true"/"false"`). Gateways differ.
 
-## 4. Pagination, async style
+## Pagination, async style
 
 We follow Qlik’s `links.next.href` cursor until it disappears. No `while` loops: we bound work with a `for` capped by `max_calls`, then break when there’s no next link.
 
@@ -272,7 +272,7 @@ Why this shape:
 > [!warning]
 > If you routinely hit `max_calls`, log the last page payload and review server-side filters or page size.
 
-## 5. Triggering & polling reloads concurrently
+## Triggering & polling reloads concurrently
 
 Reloads are fire‑and‑forget: you `POST` to start, then **poll** a status endpoint until success/failure/timeout. Async lets you trigger many reloads at once and poll them in parallel without threads.
 
@@ -352,7 +352,7 @@ async def main(app_ids):
 > [!warning]
 > Always cap total wait (`max_time_s`) and use a **bounded loop** (no `while True`). If you need jittered polling or cancellation, this method is the single place to enhance.
 
-## 6. Error handling & retries
+## Error handling & retries
 
 Async doesn’t change the fundamentals: retry what can succeed later (network hiccups), fail fast on what won’t (bad input/permissions). Keep retries close to your low‑level request helpers so the rest of the code stays clean.
 
@@ -400,7 +400,7 @@ Why this shape
 > [!tip]
 > If you need different policies (e.g., more aggressive on metadata reads than reload posts), add thin wrappers like `_request_read` / `_request_write` with different decorators, but keep the core logic in one place.
 
-## 7. Optional: Notifications
+## Optional: Notifications
 
 You often want a heads‑up when a reload fails or times out. Make it **pluggable**: accept an async callback and call it just before raising. That keeps transport details (Slack, email, PagerDuty) outside the client.
 
@@ -452,7 +452,7 @@ Why callbacks, not logging hooks
 > [!tip]
 > Keep the callback optional and fire it only on terminal failures (FAILED/ERROR/ABORTED/TIMEOUT). Success paths should remain silent.
 
-## 8. Trade-offs and takeaways
+## Trade-offs and takeaways
 
 * **Async = faster** when you need many concurrent calls.
 * **Complexity = higher**, but it’s isolated inside the client (semaphore, session, bounded polling) so call‑sites stay simple.

--- a/src/content/blog/9999-query-analysis.mdx
+++ b/src/content/blog/9999-query-analysis.mdx
@@ -10,7 +10,7 @@ tags: [SQL, DE, sqlglot, Performance, Analytics]
 draft: true
 ---
 
-## 1. Overview
+## Overview
 
 This post explains how to extract and structure SQL query insights from Athena using **sqlglot** and a custom Python parser. The focus is on building a foundation for later performance analysis rather than interpreting the results yet.
 
@@ -22,7 +22,7 @@ This guide is especially relevant if you want to:
 * Build an internal SQL insights dataset for cost/performance optimization.
 * Create a reproducible static analysis pipeline for SQL queries.
 
-## 2. Problem
+## Problem
 
 Data teams often accumulate thousands of historical SQL queries across BI tools, pipelines, and ad-hoc analysis. However, this data remains underutilized — stored as text without structure or insight.
 
@@ -43,7 +43,7 @@ The next sections detail the tools, parser, and pipeline that make this process 
 > [!warning]
 > This approach focuses solely on **static analysis** — it inspects query text, not execution results. Runtime metrics like execution time, data scanned, or bytes processed should be retrieved directly from your query engine’s system tables or APIs to complement this analysis.
 
-## 3. Extracting Query History (optional)
+## Extracting Query History (optional)
 
 > [!info]
 > This section is optional and **Athena-specific**. The post focuses on static parsing, but if you need sample input data, here’s a minimal way to fetch Athena query history. Other engines have different APIs/system tables; adjust the listing & detail calls accordingly.
@@ -111,7 +111,7 @@ executions = get_query_executions(ids)
 > [!warning]
 > Keep `max_iterations` conservative to control costs and latency. Add retries/backoff and time filtering (`started_at`) in production.
 
-## 4. Sqlglot
+## Sqlglot
 
 <FancyLink linkText="sqlglot" url="https://github.com/tobymao/sqlglot" dark="true"/> is an open-source SQL parser and transpiler that converts SQL text into an **Abstract Syntax Tree (AST)**. It’s fast, stable, and supports a wide range of dialects — including Athena, BigQuery, Presto, and Snowflake — making it a strong foundation for static query analysis.
 
@@ -130,7 +130,7 @@ In this project, `sqlglot` serves as the backbone for the **SqlAnalyzer** class 
 > [!warning]
 > While `sqlglot` can handle a large variety of dialects, some engine-specific extensions or macros (e.g., Athena comments or dbt Jinja syntax) may require pre-processing before parsing. Always sanitize queries before feeding them into the parser.
 
-### 4.1 Minimal example: parsing and inspecting a query
+### Minimal example: parsing and inspecting a query
 
 ```python
 from sqlglot import parse_one
@@ -162,12 +162,12 @@ print(f"Tables used in the query: {tables}")
 * `parse_one(..., read="athena")` builds an AST you can traverse.
 * `find_all(exp.Table)` retrieves table nodes; you can assemble `db.table` easily.
 
-## 5. SqlAnalyzer (methods)
+## SqlAnalyzer (methods)
 
 This section focuses **only on the methods** used to extract static insights from SQL text.
 We introduce the constructor and then group the public `get_*` methods by topic. Internal helpers (`_…`) appear the first time they’re referenced (inside accordions).
 
-### 5.0 Constructor
+### Constructor
 
 Parses once per query using the chosen dialect (Athena here). Everything else reads from the AST (`self.tree`).
 
@@ -178,7 +178,7 @@ class SqlAnalyzer:
         self.tree = parse_one(query.strip(), read=self.engine)
 ```
 
-### 5.1 Table lineage
+### Table lineage
 
 **What you learn:** which tables the query **reads** and which tables it **writes** to (INSERT/CTAS). This lets you attribute cost and time to specific tables and build lineage.
 
@@ -267,7 +267,7 @@ class SqlAnalyzer:
 
 </Accordion>
 
-### 5.2 Join & union metrics
+### Join & union metrics
 
 **What you learn:** amount and type of data combination and deduplication. More joins → larger intermediate data; `UNION DISTINCT` forces dedupe.
 
@@ -292,7 +292,7 @@ class SqlAnalyzer:
         return total, union_all, total - union_all
 ```
 
-### 5.3 Structural complexity
+### Structural complexity
 
 **What you learn:** how deep/complex the query is (CTEs, subqueries, windows, nesting). Higher values often correlate with slower planning and heavier shuffles.
 
@@ -327,7 +327,7 @@ class SqlAnalyzer:
         return maxd
 ```
 
-### 5.4 Predicate & projection metrics
+### Predicate & projection metrics
 
 **What you learn:** how selective and wide the query is. Large `IN` lists, long `OR` chains, function-wrapped columns, and leading-wildcard `LIKE` patterns often kill pruning and inflate scans.
 
@@ -413,7 +413,7 @@ class SqlAnalyzer:
 
 </Accordion>
 
-### 5.5 Best-practice flags
+### Best-practice flags
 
 **What you learn:** quick red flags that typically inflate cost or latency.
 
@@ -439,7 +439,7 @@ class SqlAnalyzer:
         return False
 ```
 
-### 5.6 Command classification
+### Command classification
 
 **What you learn:** whether a query performs reads only, or also DDL/DML (useful for governance and change tracking). `exp.Command` captures things like `UNLOAD`; explicit classes cover `INSERT/CREATE/ALTER/DROP`.
 
@@ -470,11 +470,11 @@ class SqlAnalyzer:
 > [!warning]
 > These methods provide **static** insights. Correlate with runtime metrics (execution time, bytes scanned, rows output) from your engine to prioritize remediation.
 
-## 6. Pipeline for Extracting Data
+## Pipeline for Extracting Data
 
 This section shows how the analyzer runs in batch (Prefect/ECS) and how results are materialized to the **Bronze** layer. We focus on how each query becomes an `AnalysisResult` record.
 
-### 6.1 Result schema (Pydantic) and `analyze`
+### Result schema (Pydantic) and `analyze`
 
 We attach a `query_id` to every result so downstream systems can trace metrics back to the original query. Failures are represented with `is_success=False`.
 
@@ -562,7 +562,7 @@ class SqlAnalyzer:
         )
 ```
 
-### 6.2 Batch extraction task (Prefect/ECS)
+### Batch extraction task (Prefect/ECS)
 
 This task queries recent Athena statements, runs the analyzer for each, and writes the results to an Iceberg-backed Bronze table.
 
@@ -609,11 +609,11 @@ def extract_batch():
 
 Each batch produces a DataFrame of analysis results, where each row represents one query and all computed metrics from `SqlAnalyzer.analyze()`.
 
-## 7. Next Steps
+## Next Steps
 
 Once the data is extracted and stored, the next phase is **analysis**. The goal is to turn raw static metrics into actionable insights for improving SQL practices across your organization.
 
-### 7.1 Analyze trends
+### Analyze trends
 
 Examine global patterns to understand how queries are written and evolve over time:
 
@@ -622,7 +622,7 @@ Examine global patterns to understand how queries are written and evolve over ti
 * Typical **AST depth** and **subquery counts** to estimate structural complexity.
 * Top N tables appearing across queries to detect heavily queried datasets.
 
-### 7.2 Establish SQL quality guidelines
+### Establish SQL quality guidelines
 
 Use these findings to propose internal standards:
 
@@ -632,7 +632,7 @@ Use these findings to propose internal standards:
 
 By periodically running this pipeline, you can detect regressions (e.g., more `SELECT *` or deeper nesting) and drive continuous improvements in your data engineering practices.
 
-### 7.3 Future extensions
+### Future extensions
 
 * **Cost integration:** correlate metrics with runtime cost (e.g., bytes scanned) for deeper efficiency analysis.
 * **Visualization:** load metrics into **Superset** or other BI tools for dashboards and trend tracking.


### PR DESCRIPTION
### Motivation
- The site was redesigned to render section numbering automatically, so existing posts with hardcoded numeric prefixes (e.g. `## 1. Intro`, `### 2.1. Details`) must be cleaned to avoid duplicated numbering.

### Description
- Strip numeric prefixes from Markdown/MDX heading lines in `src/content/blog` (e.g. `## 1. Intro` → `## Intro`), applied only to files under `src/content/blog` and skipping index files named `-index.*`.
- Operation preserves fenced code blocks and leaves code snippets untouched by treating them as excluded regions during transformation.
- Changes were applied across the blog collection (67 files modified); the replacements were implemented with a Python script that performs regex-based heading cleanup and a safer pass that preserves code fences and other edge cases.

### Testing
- Ran a validation script (`python` snippet) that scans for remaining numbered headings outside fenced code blocks and returned `remaining 0`, confirming no numbered headings remain.
- Verified the workspace diff: 67 files updated across `src/content/blog` and a balanced set of edits (insertions/deletions) reflecting heading normalization.
- Attempted a full site build with `npm run build`, but it failed in this environment due to the local Node.js version being unsupported by Astro (`Node v20.19.6` vs required `>=22.12.0`), so production build verification was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ec640e46248328b8bd15f9550d7da2)