### PR TITLE
Fix search crash on special chars, shrink index, drop marked from client

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -8,20 +8,6 @@ Audit of `villoro.com` (Astro 6 + Tailwind 4, Netlify). Proposals are grouped by
 
 ---
 
-## Bugs & Correctness
-
-### B1. Search crashes on regex special characters
-- **Current:** `SearchModal.tsx` builds `new RegExp(searchString, "gi")` from raw user input (only `\` is stripped), and `SearchResult.tsx` does the same in `matchMarker`/`matchUnderline`. Typing `(`, `c++`, or `[` throws and breaks the search UI.
-- **Change:** Escape the input (`searchString.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")`) before constructing any `RegExp`, or switch to plain `String.includes` matching.
-- **Effort:** Low / **Impact:** Medium (user-visible breakage)
-
-### B2. Search filters/renders `frontmatter.categories`, which never exists
-- **Current:** The blog schema uses `category` (singular, string). `SearchModal.doSearch` and the `SearchResult` taxonomy block reference `frontmatter.categories` (plural array) — always `undefined`, so category matching and the category chips in results are dead code.
-- **Change:** Either index `category` (and `tags`) in `scripts/jsonGenerator.js` and match on those, or delete the dead branches.
-- **Effort:** Low / **Impact:** Low–Medium
-
----
-
 ## Performance
 
 > PageSpeed Insights baseline (May 2026, homepage): **Mobile 66 / Desktop 86**. Mobile LCP **5.1s** (target ≤2.5s), FCP **3.0s**, Speed Index **12.7s**. Desktop LCP **1.3s**, Speed Index **6.1s**. CrUX field data: not enough traffic yet — these are lab numbers only. Re-run PSI after each fix to confirm impact.
@@ -36,11 +22,6 @@ Audit of `villoro.com` (Astro 6 + Tailwind 4, Netlify). Proposals are grouped by
 - **Change:** Move blog hero images to `src/images/` (where post-body images already live) and update `ImageMod`'s glob + the CI aspect-ratio path. Keeps only optimized variants in `dist`. Coordinate with P4.
 - **Effort:** Medium / **Impact:** Medium (build output size, deploy time, precache size)
 
-### P13. Shrink the search index
-- **Current:** `public/search.json` is **792 KB** and contains the raw MDX body of every post — including `import` statements and JSX shortcode markup — which the client then `plainify`s at render time. The whole file is fetched on first search open.
-- **Change:** In `scripts/jsonGenerator.js`, strip frontmatter-irrelevant fields and store plain text (run the markdown→plain conversion at generation time, truncate body to a few KB per post). Longer term, consider Pagefind for proper static search. Pairs with B2.
-- **Effort:** Low–Medium / **Impact:** Medium
-
 ### P9. Audit render-blocking requests
 - **Current:** PSI: ~150 ms mobile, ~40 ms desktop. Note `inlineStylesheets: "auto"` is **already enabled** in `astro.config.mjs`, so the original suggestion is partially done. Remaining suspects: the Google Fonts stylesheets + AstroFont (five font families total: Heebo, Signika, Fraunces, Instrument Serif, JetBrains Mono).
 - **Change:** Run a Lighthouse trace to identify remaining blockers. Consider self-hosting the fonts (fontsource) and trimming the family/weight set — five families is a lot for a blog.
@@ -51,7 +32,7 @@ Audit of `villoro.com` (Astro 6 + Tailwind 4, Netlify). Proposals are grouped by
 ## DX & Tooling
 
 ### D2. Add a test harness (Vitest)
-- Start with utilities (`textConverter`, `readingTime`, `similarItems`) and `scripts/jsonGenerator.js` (slug fallback logic is subtle). The regex-escape fix in B1 is a perfect first test case.
+- Start with utilities (`textConverter`, `readingTime`, `similarItems`) and `scripts/jsonGenerator.js` (slug fallback + MDX plainify logic is subtle and currently untested).
 - **Effort:** High / **Impact:** High
 
 ### D4. Lighthouse / Unlighthouse CI step on previews

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "villoro",
-  "version": "3.1.15",
+  "version": "3.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "villoro",
-      "version": "3.1.15",
+      "version": "3.1.16",
       "license": "MIT",
       "dependencies": {
         "@astrojs/mdx": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "villoro",
-  "version": "3.1.15",
+  "version": "3.1.16",
   "description": "My personal website",
   "author": "Arnau Villoro <arnau@villoro.com>",
   "license": "MIT",

--- a/scripts/jsonGenerator.js
+++ b/scripts/jsonGenerator.js
@@ -1,11 +1,40 @@
 const fs = require("fs");
 const path = require("path");
 const matter = require("gray-matter");
+const { marked } = require("marked");
 
 const CONTENT_DEPTH = 2;
 const JSON_FOLDER = "./.json";
 const PUBLIC_FOLDER = "./public";
 const BLOG_FOLDER = "src/content/blog";
+
+// Cap the indexed body per post so search.json stays small. Plain text only —
+// long posts lose tail-end recall, which is an acceptable trade-off.
+const MAX_CONTENT_LENGTH = 5000;
+
+// Convert MDX to plain text at build time so the client doesn't need to parse
+// markdown (this keeps `marked` out of the browser bundle — see SearchResult).
+const plainify = (mdxContent) => {
+  const withoutImports = mdxContent.replace(/^(import|export)\s.*$/gm, "");
+  // strip MDX component tags (capitalized, possibly multiline attributes,
+  // e.g. <FancyLink linkText="…" url="…"/>) before markdown parsing —
+  // marked escapes them in some contexts so the HTML-tag strip below
+  // wouldn't catch them
+  const withoutComponents = withoutImports.replace(
+    /<\/?[A-Z][a-zA-Z]*(\s[^<>]*?)?\/?>/gs,
+    " ",
+  );
+  const html = marked.parse(withoutComponents);
+  const withoutTags = html.replace(/<\/?[^>]+(>|$)/gm, " ");
+  const decoded = withoutTags
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+  return decoded.replace(/\s+/g, " ").trim();
+};
 
 // get data from markdown
 const getData = (folder, groupDepth) => {
@@ -22,6 +51,11 @@ const getData = (folder, groupDepth) => {
     } else if (filename.endsWith(".md") || filename.endsWith(".mdx")) {
       const file = fs.readFileSync(filepath, "utf-8");
       const { data, content } = matter(file);
+
+      // skip drafts here — the slimmed frontmatter below no longer carries
+      // the `draft` flag, so it can't be filtered later
+      if (data.draft) return [];
+
       const pathParts = filepath.split(path.sep);
       const slug =
         data.slug ||
@@ -34,18 +68,21 @@ const getData = (folder, groupDepth) => {
       return {
         group: group,
         slug: slug,
-        frontmatter: data,
-        content: content,
+        frontmatter: {
+          title: data.title,
+          description: data.description,
+          image: data.image,
+          category: data.category,
+          tags: data.tags,
+        },
+        content: plainify(content).slice(0, MAX_CONTENT_LENGTH),
       };
     } else {
       return [];
     }
   });
 
-  const publishedPages = getPaths.filter(
-    (page) => !page.frontmatter?.draft && page,
-  );
-  return publishedPages;
+  return getPaths;
 };
 
 try {

--- a/src/layouts/helpers/SearchModal.tsx
+++ b/src/layouts/helpers/SearchModal.tsx
@@ -9,25 +9,28 @@ const SearchModal = () => {
 
   // handle input change
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchString(e.currentTarget.value.replace("\\", "").toLowerCase());
+    setSearchString(e.currentTarget.value.toLowerCase());
   };
 
-  // generate search result
+  // generate search result — plain substring matching; the query is user
+  // text, never a regex (raw input like "c++" or "(" would throw in RegExp)
   const doSearch = (data: ISearchItem[] | null) => {
     if (!data || searchString === "") return [];
-    const regex = new RegExp(`${searchString}`, "gi");
     return data.filter((item) => {
-      const title = item.frontmatter.title.toLowerCase().match(regex);
+      const title = item.frontmatter.title.toLowerCase().includes(searchString);
       const description = item.frontmatter.description
         ?.toLowerCase()
-        .match(regex);
-      const categories = item.frontmatter.categories
+        .includes(searchString);
+      const category = item.frontmatter.category
+        ?.toLowerCase()
+        .includes(searchString);
+      const tags = item.frontmatter.tags
         ?.join(" ")
         .toLowerCase()
-        .match(regex);
-      const content = item.content.toLowerCase().match(regex);
+        .includes(searchString);
+      const content = item.content.toLowerCase().includes(searchString);
 
-      return Boolean(title || content || description || categories);
+      return Boolean(title || content || description || category || tags);
     });
   };
 

--- a/src/layouts/helpers/SearchResult.tsx
+++ b/src/layouts/helpers/SearchResult.tsx
@@ -1,4 +1,3 @@
-import { plainify, titleify } from "@/lib/utils/textConverter";
 import React from "react";
 
 export interface ISearchItem {
@@ -8,23 +7,28 @@ export interface ISearchItem {
     title: string;
     image?: string;
     description?: string;
-    categories?: string[];
+    category?: string;
+    tags?: string[];
   };
+  // plain text, pre-converted from MDX by scripts/jsonGenerator.js — do NOT
+  // import markdown helpers here, they would pull `marked` into the bundle
   content: string;
 }
 
+// local title-case helper (intentionally not imported from textConverter,
+// which transitively imports `marked`)
+const titleify = (content: string): string => {
+  return content
+    .replace(/^[\s_-]+|[\s_-]+$/g, "")
+    .replace(/[_\s-]+/g, " ")
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+};
+
 export interface ISearchGroup {
   group: string;
-  groupItems: {
-    slug: string;
-    frontmatter: {
-      title: string;
-      image?: string;
-      description?: string;
-      categories?: string[];
-    };
-    content: string;
-  }[];
+  groupItems: ISearchItem[];
 }
 
 // search result component
@@ -45,20 +49,10 @@ const SearchResult = ({
         if (groupIndex === -1) {
           groupItems.push({
             group: item.group,
-            groupItems: [
-              {
-                frontmatter: { ...item.frontmatter },
-                slug: item.slug,
-                content: item.content,
-              },
-            ],
+            groupItems: [item],
           });
         } else {
-          groupItems[groupIndex].groupItems.push({
-            frontmatter: { ...item.frontmatter },
-            slug: item.slug,
-            content: item.content,
-          });
+          groupItems[groupIndex].groupItems.push(item);
         }
 
         return groupItems;
@@ -69,9 +63,14 @@ const SearchResult = ({
   };
   const finalResult = generateSearchGroup(searchResult);
 
+  // escape user input before building a RegExp from it — raw input like
+  // "c++" or "(" is an invalid pattern and would throw
+  const escapeRegExp = (text: string) =>
+    text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
   // match marker
   const matchMarker = (text: string, substring: string) => {
-    const parts = text.split(new RegExp(`(${substring})`, "gi"));
+    const parts = text.split(new RegExp(`(${escapeRegExp(substring)})`, "gi"));
     return parts.map((part, index) =>
       part.toLowerCase() === substring.toLowerCase() ? (
         <mark key={index}>{part}</mark>
@@ -83,7 +82,9 @@ const SearchResult = ({
 
   // match underline
   const matchUnderline = (text: string, substring: string) => {
-    const parts = text?.split(new RegExp(`(${substring})`, "gi"));
+    const parts = text?.split(
+      new RegExp(`(${escapeRegExp(substring)})`, "gi")
+    );
     return parts?.map((part, index) =>
       part.toLowerCase() === substring.toLowerCase() ? (
         <span key={index} className="underline">
@@ -95,24 +96,23 @@ const SearchResult = ({
     );
   };
 
-  // match content
+  // match content — show a snippet around the first occurrence, or the start
+  // of the post when the match was on title/description/taxonomy only
   const matchContent = (content: string, substring: string) => {
-    const plainContent = plainify(content);
-    const position = plainContent
-      .toLowerCase()
-      .indexOf(substring.toLowerCase());
+    const position = content.toLowerCase().indexOf(substring.toLowerCase());
+
+    if (position === -1) {
+      return <>{content.substring(0, 80)}</>;
+    }
 
     // Find the start of the word containing the substring
     let wordStart = position;
-    while (wordStart > 0 && plainContent[wordStart - 1] !== " ") {
+    while (wordStart > 0 && content[wordStart - 1] !== " ") {
       wordStart--;
     }
 
-    const matches = plainContent.substring(
-      wordStart,
-      substring.length + position
-    );
-    const matchesAfter = plainContent.substring(
+    const matches = content.substring(wordStart, substring.length + position);
+    const matchesAfter = content.substring(
       substring.length + position,
       substring.length + position + 80
     );
@@ -170,7 +170,7 @@ const SearchResult = ({
                         </p>
                       )}
                       <div className="search-result-item-taxonomies">
-                        {item.frontmatter.categories && (
+                        {item.frontmatter.category && (
                           <div className="mr-2">
                             <svg
                               width="14"
@@ -180,20 +180,27 @@ const SearchResult = ({
                             >
                               <path d="M11 0H3a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2 2 2 0 0 0 2-2V4a2 2 0 0 0-2-2 2 2 0 0 0-2-2zm2 3a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1V3zM2 2a1 1 0 0 1 1-1h8a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V2z"></path>
                             </svg>
-                            {item.frontmatter.categories.map(
-                              (category, index) => (
-                                <span key={category}>
-                                  {matchUnderline(category, searchString)}
-                                  {item.frontmatter.categories &&
-                                    index !==
-                                      item.frontmatter.categories.length - 1 && (
-                                      <>, </>
-                                    )}
-                                </span>
-                              )
-                            )}
+                            <span>
+                              {matchUnderline(
+                                item.frontmatter.category,
+                                searchString
+                              )}
+                            </span>
                           </div>
                         )}
+                        {item.frontmatter.tags &&
+                          item.frontmatter.tags.length > 0 && (
+                            <div className="mr-2">
+                              {item.frontmatter.tags.map((tag, index) => (
+                                <span key={tag}>
+                                  #{matchUnderline(tag, searchString)}
+                                  {index !==
+                                    (item.frontmatter.tags?.length ?? 0) -
+                                      1 && <> </>}
+                                </span>
+                              ))}
+                            </div>
+                          )}
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
Three related search fixes: (1) queries like 'c++' or '(' crashed the search UI because raw input was fed to new RegExp() in SearchModal and SearchResult — matching now uses String.includes and highlight patterns are regex-escaped. (2) The index stored raw MDX (imports, JSX shortcodes) that the client plainified with marked on every render; jsonGenerator now converts to plain text at build time, slims frontmatter to the used fields, and caps body at 5000 chars: search.json drops 792 KB -> 333 KB and the SearchModal bundle 44 KB -> 9 KB (marked no longer ships to the browser). (3) Search matched/rendered frontmatter.categories which never exists (schema has singular category) — now indexes and matches category + tags and renders them in results. Drafts are filtered at read time since the slimmed frontmatter no longer carries the draft flag.

Verified in astro preview: crash inputs return results, snippets/links/taxonomies render, no console errors. Removes B1/B2/P13 from IMPROVEMENTS.md.