### PR TITLE
Track writing and update dates for posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "villoro",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "villoro",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "MIT",
       "dependencies": {
         "@astrojs/markdown-remark": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "villoro",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "My personal website",
   "author": "Arnau Villoro <arnau@villoro.com>",
   "license": "MIT",

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,6 +10,8 @@ const blogCollection = defineCollection({
     description: z.string().optional(),
     date: z.date().optional(),
     updatedDate: z.date().optional(),
+    // Internal only: when the post was written; never rendered
+    writingDate: z.date().optional(),
     image: z.string().optional(),
     imageAlt: z.string().optional(),
     readingTime: z.number().int().positive().optional(),

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,9 +9,9 @@ const blogCollection = defineCollection({
     meta_title: z.string().optional(),
     description: z.string().optional(),
     date: z.date().optional(),
-    updatedDate: z.date().optional(),
+    updated_date: z.date().optional(),
     // Internal only: when the post was written; never rendered
-    writingDate: z.date().optional(),
+    writing_date: z.date().optional(),
     image: z.string().optional(),
     imageAlt: z.string().optional(),
     readingTime: z.number().int().positive().optional(),

--- a/src/content/blog/0001-personal_web.mdx
+++ b/src/content/blog/0001-personal_web.mdx
@@ -4,8 +4,8 @@ title: Personal webpage
 meta_title: Personal webpage
 description: I used to have a personal webpage made with WordPress. Since I have been working as a developer for some years I decided that I could create something that better suited my needs.
 date: 2018-12-27
-writingDate: 2018-12-27
-updatedDate: 2019-03-02
+writing_date: 2018-12-27
+updated_date: 2019-03-02
 image: /images/blog/0001-personal-web.png
 category: web
 tags: [Web, Python, Setup]

--- a/src/content/blog/0001-personal_web.mdx
+++ b/src/content/blog/0001-personal_web.mdx
@@ -4,6 +4,8 @@ title: Personal webpage
 meta_title: Personal webpage
 description: I used to have a personal webpage made with WordPress. Since I have been working as a developer for some years I decided that I could create something that better suited my needs.
 date: 2018-12-27
+writingDate: 2018-12-27
+updatedDate: 2019-03-02
 image: /images/blog/0001-personal-web.png
 category: web
 tags: [Web, Python, Setup]

--- a/src/content/blog/0002-black.mdx
+++ b/src/content/blog/0002-black.mdx
@@ -7,6 +7,8 @@ description: |
   By using it, you agree to cede control over minutiae of hand-formatting.
   In return, Black gives you speed, determinism, and freedom from pycodestyle nagging about formatting.
 date: 2019-02-07
+writingDate: 2019-02-07
+updatedDate: 2019-03-02
 image: /images/blog/0002-black-calligraphy.jpg
 category: python
 tags: [Python, Tools, Best Practices]

--- a/src/content/blog/0002-black.mdx
+++ b/src/content/blog/0002-black.mdx
@@ -7,8 +7,8 @@ description: |
   By using it, you agree to cede control over minutiae of hand-formatting.
   In return, Black gives you speed, determinism, and freedom from pycodestyle nagging about formatting.
 date: 2019-02-07
-writingDate: 2019-02-07
-updatedDate: 2019-03-02
+writing_date: 2019-02-07
+updated_date: 2019-03-02
 image: /images/blog/0002-black-calligraphy.jpg
 category: python
 tags: [Python, Tools, Best Practices]

--- a/src/content/blog/0003-sql_alchemy.mdx
+++ b/src/content/blog/0003-sql_alchemy.mdx
@@ -4,8 +4,8 @@ title: SQL Alchemy with python
 meta_title: SQL Alchemy
 description: SQL is one of the most relevant languages for databases. So at one point you will need to interact to get, store or modify some data. Fortunately you can do it in python using SQL Alchemy.
 date: 2019-02-08
-writingDate: 2019-02-08
-updatedDate: 2019-10-09
+writing_date: 2019-02-08
+updated_date: 2019-10-09
 image: /images/blog/0003-alchemy-table.jpg
 category: DE
 tags: [Python, SQL, Intro, Tutorial]

--- a/src/content/blog/0003-sql_alchemy.mdx
+++ b/src/content/blog/0003-sql_alchemy.mdx
@@ -4,6 +4,8 @@ title: SQL Alchemy with python
 meta_title: SQL Alchemy
 description: SQL is one of the most relevant languages for databases. So at one point you will need to interact to get, store or modify some data. Fortunately you can do it in python using SQL Alchemy.
 date: 2019-02-08
+writingDate: 2019-02-08
+updatedDate: 2019-10-09
 image: /images/blog/0003-alchemy-table.jpg
 category: DE
 tags: [Python, SQL, Intro, Tutorial]

--- a/src/content/blog/0004-colors.mdx
+++ b/src/content/blog/0004-colors.mdx
@@ -4,8 +4,8 @@ title: Using Material colors and other palettes
 meta_title: Material colors and palettes
 description: Choosing between colors is always a difficult task. But with the material design palette it is possible to solve most of color related problems easily.
 date: 2019-02-15
-writingDate: 2019-02-15
-updatedDate: 2019-04-07
+writing_date: 2019-02-15
+updated_date: 2019-04-13
 image: /images/blog/0004-material-colors.png
 category: web
 tags: [Python, Web, Best Practices]

--- a/src/content/blog/0004-colors.mdx
+++ b/src/content/blog/0004-colors.mdx
@@ -4,6 +4,8 @@ title: Using Material colors and other palettes
 meta_title: Material colors and palettes
 description: Choosing between colors is always a difficult task. But with the material design palette it is possible to solve most of color related problems easily.
 date: 2019-02-15
+writingDate: 2019-02-15
+updatedDate: 2019-04-07
 image: /images/blog/0004-material-colors.png
 category: web
 tags: [Python, Web, Best Practices]

--- a/src/content/blog/0005-strings_python.mdx
+++ b/src/content/blog/0005-strings_python.mdx
@@ -4,6 +4,8 @@ title: String best practices with Python
 meta_title: String best practices
 description: There are a lot of ways to work with strings in Python. And there are some cool tricks I want to share that will make it easier to deal with strings.
 date: 2019-02-16
+writingDate: 2019-02-16
+updatedDate: 2025-08-18
 image: /images/blog/0005-cutting-string.jpg
 category: python
 tags: [Python, Best Practices]

--- a/src/content/blog/0005-strings_python.mdx
+++ b/src/content/blog/0005-strings_python.mdx
@@ -4,8 +4,8 @@ title: String best practices with Python
 meta_title: String best practices
 description: There are a lot of ways to work with strings in Python. And there are some cool tricks I want to share that will make it easier to deal with strings.
 date: 2019-02-16
-writingDate: 2019-02-16
-updatedDate: 2025-08-18
+writing_date: 2019-02-16
+updated_date: 2025-08-18
 image: /images/blog/0005-cutting-string.jpg
 category: python
 tags: [Python, Best Practices]

--- a/src/content/blog/0006-singleton.mdx
+++ b/src/content/blog/0006-singleton.mdx
@@ -4,8 +4,8 @@ title: Singleton in Python
 meta_title: Singleton in Python
 description: The singleton pattern will help you have only one instance and allow you to call only one sync function.
 date: 2019-02-24
-writingDate: 2019-02-24
-updatedDate: 2025-05-05
+writing_date: 2019-02-24
+updated_date: 2025-05-05
 image: /images/blog/0006-singleton-king.jpg
 category: python
 tags: [Python]

--- a/src/content/blog/0006-singleton.mdx
+++ b/src/content/blog/0006-singleton.mdx
@@ -4,6 +4,8 @@ title: Singleton in Python
 meta_title: Singleton in Python
 description: The singleton pattern will help you have only one instance and allow you to call only one sync function.
 date: 2019-02-24
+writingDate: 2019-02-24
+updatedDate: 2025-05-05
 image: /images/blog/0006-singleton-king.jpg
 category: python
 tags: [Python]

--- a/src/content/blog/0007-blog_basic_tools.mdx
+++ b/src/content/blog/0007-blog_basic_tools.mdx
@@ -4,8 +4,8 @@ title: Basic tools for blogs
 meta_title: Basic tools for blogs
 description: View how to set up a mailing list (Mailchimp), add a comments section (Disqus) on posts and track visits (Google Analytics).
 date: 2019-03-02
-writingDate: 2019-03-02
-updatedDate: 2024-07-17
+writing_date: 2019-03-02
+updated_date: 2024-07-17
 image: /images/blog/0007-golden-dj-monkey.jpg
 category: tools
 tags: [Web, Tools, Setup]

--- a/src/content/blog/0007-blog_basic_tools.mdx
+++ b/src/content/blog/0007-blog_basic_tools.mdx
@@ -4,6 +4,8 @@ title: Basic tools for blogs
 meta_title: Basic tools for blogs
 description: View how to set up a mailing list (Mailchimp), add a comments section (Disqus) on posts and track visits (Google Analytics).
 date: 2019-03-02
+writingDate: 2019-03-02
+updatedDate: 2024-07-17
 image: /images/blog/0007-golden-dj-monkey.jpg
 category: tools
 tags: [Web, Tools, Setup]

--- a/src/content/blog/0008-static_webpage.mdx
+++ b/src/content/blog/0008-static_webpage.mdx
@@ -4,6 +4,8 @@ title: How to create a static website
 meta_title: How to create a static web
 description: See how I created a static webpage in some minutes. And how you can do it too.
 date: 2019-03-12
+writingDate: 2019-03-12
+updatedDate: 2019-04-12
 image: /images/blog/0008-static-mountain.jpg
 category: web
 tags: [Python, Web, Tutorial, Setup]

--- a/src/content/blog/0008-static_webpage.mdx
+++ b/src/content/blog/0008-static_webpage.mdx
@@ -4,8 +4,8 @@ title: How to create a static website
 meta_title: How to create a static web
 description: See how I created a static webpage in some minutes. And how you can do it too.
 date: 2019-03-12
-writingDate: 2019-03-12
-updatedDate: 2019-04-12
+writing_date: 2019-03-12
+updated_date: 2019-04-22
 image: /images/blog/0008-static-mountain.jpg
 category: web
 tags: [Python, Web, Tutorial, Setup]

--- a/src/content/blog/0009-aws_ec2.mdx
+++ b/src/content/blog/0009-aws_ec2.mdx
@@ -4,6 +4,8 @@ title: Creating EC2 instances in AWS
 meta_title: Creating EC2 instances
 description: How to create an EC2 AWS instance. Detailed instructions on how to do it in some minutes.
 date: 2019-03-18
+writingDate: 2019-03-18
+updatedDate: 2019-04-24
 image: /images/blog/0009-aws-ec2.jpg
 category: cloud_devops
 tags: [AWS, Tutorial, Setup]

--- a/src/content/blog/0009-aws_ec2.mdx
+++ b/src/content/blog/0009-aws_ec2.mdx
@@ -4,8 +4,8 @@ title: Creating EC2 instances in AWS
 meta_title: Creating EC2 instances
 description: How to create an EC2 AWS instance. Detailed instructions on how to do it in some minutes.
 date: 2019-03-18
-writingDate: 2019-03-18
-updatedDate: 2019-04-24
+writing_date: 2019-03-18
+updated_date: 2019-04-24
 image: /images/blog/0009-aws-ec2.jpg
 category: cloud_devops
 tags: [AWS, Tutorial, Setup]

--- a/src/content/blog/0010-airflow.mdx
+++ b/src/content/blog/0010-airflow.mdx
@@ -4,6 +4,8 @@ title: Setting up Airflow
 meta_title: Setting up Airflow
 description: How to set up Apache Airflow, the platform to programmatically author, schedule and monitor workflows.
 date: 2019-03-19
+writingDate: 2019-03-19
+updatedDate: 2020-01-06
 image: /images/blog/0010-airflow.jpg
 category: cloud_devops
 tags: [Tools, Orchestration, Tutorial, Setup]

--- a/src/content/blog/0010-airflow.mdx
+++ b/src/content/blog/0010-airflow.mdx
@@ -4,8 +4,8 @@ title: Setting up Airflow
 meta_title: Setting up Airflow
 description: How to set up Apache Airflow, the platform to programmatically author, schedule and monitor workflows.
 date: 2019-03-19
-writingDate: 2019-03-19
-updatedDate: 2020-01-06
+writing_date: 2019-03-19
+updated_date: 2020-01-06
 image: /images/blog/0010-airflow.jpg
 category: cloud_devops
 tags: [Tools, Orchestration, Tutorial, Setup]

--- a/src/content/blog/0011-nginx_gunicorn.mdx
+++ b/src/content/blog/0011-nginx_gunicorn.mdx
@@ -4,8 +4,8 @@ title: Serving python apps with nginx and gunicorn
 meta_title: Serving python apps
 description: How to serve Python apps with nginx and gunicorn.
 date: 2019-03-21
-writingDate: 2019-03-21
-updatedDate: 2024-07-17
+writing_date: 2019-03-21
+updated_date: 2024-07-17
 image: /images/blog/0011-green-unicorn-cape.jpg
 category: web
 tags: [Python, Web]

--- a/src/content/blog/0011-nginx_gunicorn.mdx
+++ b/src/content/blog/0011-nginx_gunicorn.mdx
@@ -4,6 +4,8 @@ title: Serving python apps with nginx and gunicorn
 meta_title: Serving python apps
 description: How to serve Python apps with nginx and gunicorn.
 date: 2019-03-21
+writingDate: 2019-03-21
+updatedDate: 2024-07-17
 image: /images/blog/0011-green-unicorn-cape.jpg
 category: web
 tags: [Python, Web]

--- a/src/content/blog/0012-tables_format.mdx
+++ b/src/content/blog/0012-tables_format.mdx
@@ -4,6 +4,8 @@ title: Storing tables efficiently with Pandas
 meta_title: Storing tables efficiently
 description: When working with pandas people usually need to store one or more tables. There are a lot of different formats to do that. In this post I am going to compare the performance between them.
 date: 2019-04-03
+writingDate: 2019-04-03
+updatedDate: 2019-04-07
 image: /images/blog/0012-tables.jpg
 category: DE
 tags: [Python, Benchmark, Performance]

--- a/src/content/blog/0012-tables_format.mdx
+++ b/src/content/blog/0012-tables_format.mdx
@@ -4,8 +4,8 @@ title: Storing tables efficiently with Pandas
 meta_title: Storing tables efficiently
 description: When working with pandas people usually need to store one or more tables. There are a lot of different formats to do that. In this post I am going to compare the performance between them.
 date: 2019-04-03
-writingDate: 2019-04-03
-updatedDate: 2019-04-07
+writing_date: 2019-04-03
+updated_date: 2020-02-19
 image: /images/blog/0012-tables.jpg
 category: DE
 tags: [Python, Benchmark, Performance]

--- a/src/content/blog/0013-intro_machine_learning.mdx
+++ b/src/content/blog/0013-intro_machine_learning.mdx
@@ -4,7 +4,8 @@ title: Intro to Machine Learning (ML)
 meta_title: Intro to Machine Learning
 description: An introduction to what Machine Learning is and how it works using a real example.
 date: 2019-04-12
-writingDate: 2019-04-12
+writing_date: 2019-04-12
+updated_date: 2024-03-26
 image: /images/blog/0013-blackboard-ml.jpg
 category: AI
 tags: [Python, ML, Intro, Tutorial]

--- a/src/content/blog/0013-intro_machine_learning.mdx
+++ b/src/content/blog/0013-intro_machine_learning.mdx
@@ -4,6 +4,7 @@ title: Intro to Machine Learning (ML)
 meta_title: Intro to Machine Learning
 description: An introduction to what Machine Learning is and how it works using a real example.
 date: 2019-04-12
+writingDate: 2019-04-12
 image: /images/blog/0013-blackboard-ml.jpg
 category: AI
 tags: [Python, ML, Intro, Tutorial]

--- a/src/content/blog/0014-decorators.mdx
+++ b/src/content/blog/0014-decorators.mdx
@@ -4,8 +4,8 @@ title: Python decorators
 meta_title: Python decorators
 description: Decorators are a really useful tool for python development but not a lot of people know what they are and how they work. In this post you are going to master them so that you can use them and create your own.
 date: 2019-04-16
-writingDate: 2019-04-16
-updatedDate: 2020-01-14
+writing_date: 2019-04-16
+updated_date: 2020-01-14
 image: /images/blog/0014-decorators.jpg
 category: python
 tags: [Python]

--- a/src/content/blog/0014-decorators.mdx
+++ b/src/content/blog/0014-decorators.mdx
@@ -4,6 +4,8 @@ title: Python decorators
 meta_title: Python decorators
 description: Decorators are a really useful tool for python development but not a lot of people know what they are and how they work. In this post you are going to master them so that you can use them and create your own.
 date: 2019-04-16
+writingDate: 2019-04-16
+updatedDate: 2020-01-14
 image: /images/blog/0014-decorators.jpg
 category: python
 tags: [Python]

--- a/src/content/blog/0015-aws_lambda.mdx
+++ b/src/content/blog/0015-aws_lambda.mdx
@@ -4,8 +4,8 @@ title: Using AWS Lambda to control EC2 instances
 meta_title: Using AWS Lambda to control EC2 instances
 description: Learn how to use AWS Lambdas to start/stop EC2 and RDS instances using an API.
 date: 2019-04-23
-writingDate: 2019-04-23
-updatedDate: 2019-05-12
+writing_date: 2019-04-23
+updated_date: 2019-05-12
 image: /images/blog/0015-lambda-reactor.jpg
 category: cloud_devops
 tags: [Python, AWS]

--- a/src/content/blog/0015-aws_lambda.mdx
+++ b/src/content/blog/0015-aws_lambda.mdx
@@ -4,6 +4,8 @@ title: Using AWS Lambda to control EC2 instances
 meta_title: Using AWS Lambda to control EC2 instances
 description: Learn how to use AWS Lambdas to start/stop EC2 and RDS instances using an API.
 date: 2019-04-23
+writingDate: 2019-04-23
+updatedDate: 2019-05-12
 image: /images/blog/0015-lambda-reactor.jpg
 category: cloud_devops
 tags: [Python, AWS]

--- a/src/content/blog/0016-pypi.mdx
+++ b/src/content/blog/0016-pypi.mdx
@@ -4,7 +4,7 @@ title: Creating Python packages
 meta_title: Creating Python packages
 description: Learn how to create a python package that can be installed with pip.
 date: 2019-05-02
-writingDate: 2019-05-02
+writing_date: 2019-05-02
 image: /images/blog/0016-pypi-library.jpg
 category: python
 tags: [Python, Tools, PyPI]

--- a/src/content/blog/0016-pypi.mdx
+++ b/src/content/blog/0016-pypi.mdx
@@ -4,6 +4,7 @@ title: Creating Python packages
 meta_title: Creating Python packages
 description: Learn how to create a python package that can be installed with pip.
 date: 2019-05-02
+writingDate: 2019-05-02
 image: /images/blog/0016-pypi-library.jpg
 category: python
 tags: [Python, Tools, PyPI]

--- a/src/content/blog/0017-passwords_encryption.mdx
+++ b/src/content/blog/0017-passwords_encryption.mdx
@@ -4,8 +4,8 @@ title: Encrypting secrets with python
 meta_title: Encrypting secrets with python
 description: Learn how a team can work securely with password by storing them encrypted in a dictionary-like file.
 date: 2019-05-10
-writingDate: 2019-05-10
-updatedDate: 2019-05-12
+writing_date: 2019-05-10
+updated_date: 2019-05-12
 image: /images/blog/0017-passwords-encryption.jpg
 category: python
 tags: [Python, Security]

--- a/src/content/blog/0017-passwords_encryption.mdx
+++ b/src/content/blog/0017-passwords_encryption.mdx
@@ -4,6 +4,8 @@ title: Encrypting secrets with python
 meta_title: Encrypting secrets with python
 description: Learn how a team can work securely with password by storing them encrypted in a dictionary-like file.
 date: 2019-05-10
+writingDate: 2019-05-10
+updatedDate: 2019-05-12
 image: /images/blog/0017-passwords-encryption.jpg
 category: python
 tags: [Python, Security]

--- a/src/content/blog/0018-logging.mdx
+++ b/src/content/blog/0018-logging.mdx
@@ -4,7 +4,7 @@ title: Logging with python
 meta_title: Logging with python
 description: An overview of my own custom logging library that handles console and file output.
 date: 2019-05-16
-writingDate: 2019-05-16
+writing_date: 2019-05-16
 image: /images/blog/0018-logging.jpg
 category: python
 tags: [Python, Tools]

--- a/src/content/blog/0018-logging.mdx
+++ b/src/content/blog/0018-logging.mdx
@@ -4,6 +4,7 @@ title: Logging with python
 meta_title: Logging with python
 description: An overview of my own custom logging library that handles console and file output.
 date: 2019-05-16
+writingDate: 2019-05-16
 image: /images/blog/0018-logging.jpg
 category: python
 tags: [Python, Tools]

--- a/src/content/blog/0019-numba.mdx
+++ b/src/content/blog/0019-numba.mdx
@@ -4,7 +4,8 @@ title: Improving python performance with Numba
 meta_title: Improving python performance with Numba
 description: Numba translates Python functions to optimized machine code at runtime. Numba-compiled numerical algorithms in Python can approach the speeds of C or FORTRAN.
 date: 2019-05-21
-writingDate: 2019-05-21
+writing_date: 2019-05-21
+updated_date: 2020-02-19
 image: /images/blog/0019-numba.jpg
 category: python
 tags: [Python, Benchmark, Performance]

--- a/src/content/blog/0019-numba.mdx
+++ b/src/content/blog/0019-numba.mdx
@@ -4,6 +4,7 @@ title: Improving python performance with Numba
 meta_title: Improving python performance with Numba
 description: Numba translates Python functions to optimized machine code at runtime. Numba-compiled numerical algorithms in Python can approach the speeds of C or FORTRAN.
 date: 2019-05-21
+writingDate: 2019-05-21
 image: /images/blog/0019-numba.jpg
 category: python
 tags: [Python, Benchmark, Performance]

--- a/src/content/blog/0020-gitflow.mdx
+++ b/src/content/blog/0020-gitflow.mdx
@@ -4,8 +4,8 @@ title: Using gitflow for code control
 meta_title: Using gitflow for code control
 description: "Development good practices: how to using gitflow as code control."
 date: 2019-06-04
-writingDate: 2019-06-04
-updatedDate: 2019-12-21
+writing_date: 2019-06-04
+updated_date: 2019-12-21
 image: /images/blog/0020-gitflow-hero.jpg
 category: git
 tags: [GIT, Best Practices]

--- a/src/content/blog/0020-gitflow.mdx
+++ b/src/content/blog/0020-gitflow.mdx
@@ -4,6 +4,8 @@ title: Using gitflow for code control
 meta_title: Using gitflow for code control
 description: "Development good practices: how to using gitflow as code control."
 date: 2019-06-04
+writingDate: 2019-06-04
+updatedDate: 2019-12-21
 image: /images/blog/0020-gitflow-hero.jpg
 category: git
 tags: [GIT, Best Practices]

--- a/src/content/blog/0021-git_ssh.mdx
+++ b/src/content/blog/0021-git_ssh.mdx
@@ -4,8 +4,8 @@ title: Using git with SSH
 meta_title: Using git with SSH
 description: Learn how to work securely with git by using SSH authentication with github.
 date: 2019-06-15
-writingDate: 2019-06-15
-updatedDate: 2026-06-29
+writing_date: 2019-06-15
+updated_date: 2026-06-29
 image: /images/blog/0021-hacker-ssh.jpg
 category: git
 tags: [GIT, Security, Setup]

--- a/src/content/blog/0021-git_ssh.mdx
+++ b/src/content/blog/0021-git_ssh.mdx
@@ -4,6 +4,8 @@ title: Using git with SSH
 meta_title: Using git with SSH
 description: Learn how to work securely with git by using SSH authentication with github.
 date: 2019-06-15
+writingDate: 2019-06-15
+updatedDate: 2026-06-29
 image: /images/blog/0021-hacker-ssh.jpg
 category: git
 tags: [GIT, Security, Setup]

--- a/src/content/blog/0022-google_analytics_etl.mdx
+++ b/src/content/blog/0022-google_analytics_etl.mdx
@@ -5,8 +5,8 @@ meta_title: Google Analytics ETL with python
 description: Google Analytics is really useful but sometimes you want to retrieve all the data and perform your own analysis and create your reports.
   In this post you will see how to do that with python.
 date: 2019-07-04
-writingDate: 2019-07-04
-updatedDate: 2019-07-13
+writing_date: 2019-07-04
+updated_date: 2019-07-13
 image: /images/blog/0022-computer-google-analytics.jpg
 category: API
 tags: [API, Python, Pandas, DE, Tutorial]

--- a/src/content/blog/0022-google_analytics_etl.mdx
+++ b/src/content/blog/0022-google_analytics_etl.mdx
@@ -5,6 +5,8 @@ meta_title: Google Analytics ETL with python
 description: Google Analytics is really useful but sometimes you want to retrieve all the data and perform your own analysis and create your reports.
   In this post you will see how to do that with python.
 date: 2019-07-04
+writingDate: 2019-07-04
+updatedDate: 2019-07-13
 image: /images/blog/0022-computer-google-analytics.jpg
 category: API
 tags: [API, Python, Pandas, DE, Tutorial]

--- a/src/content/blog/0023-dropbox_python.mdx
+++ b/src/content/blog/0023-dropbox_python.mdx
@@ -4,6 +4,8 @@ title: Reading and writing files with python using Dropbox
 meta_title: Reading and writing files with python using Dropbox
 description: Learn how to read, write and delete all kind of files using the dropbox library for python.
 date: 2019-09-14
+writingDate: 2019-09-14
+updatedDate: 2020-05-16
 image: /images/blog/0023-python-and-panda-read-dropbox.jpg
 category: DE
 tags: [Python, Pandas, DE]

--- a/src/content/blog/0023-dropbox_python.mdx
+++ b/src/content/blog/0023-dropbox_python.mdx
@@ -4,8 +4,8 @@ title: Reading and writing files with python using Dropbox
 meta_title: Reading and writing files with python using Dropbox
 description: Learn how to read, write and delete all kind of files using the dropbox library for python.
 date: 2019-09-14
-writingDate: 2019-09-14
-updatedDate: 2020-05-16
+writing_date: 2019-09-14
+updated_date: 2020-05-16
 image: /images/blog/0023-python-and-panda-read-dropbox.jpg
 category: DE
 tags: [Python, Pandas, DE]

--- a/src/content/blog/0024-pandas_intro.mdx
+++ b/src/content/blog/0024-pandas_intro.mdx
@@ -4,8 +4,8 @@ title: Pandas Intro
 meta_title: Pandas Intro
 description: Learn how to use python pandas library to work with tabular data.
 date: 2019-11-01
-writingDate: 2019-11-01
-updatedDate: 2019-11-02
+writing_date: 2019-11-01
+updated_date: 2019-11-02
 image: /images/blog/0024-working-pandas.jpg
 category: DE
 tags: [Python, Pandas, Intro]

--- a/src/content/blog/0024-pandas_intro.mdx
+++ b/src/content/blog/0024-pandas_intro.mdx
@@ -4,6 +4,8 @@ title: Pandas Intro
 meta_title: Pandas Intro
 description: Learn how to use python pandas library to work with tabular data.
 date: 2019-11-01
+writingDate: 2019-11-01
+updatedDate: 2019-11-02
 image: /images/blog/0024-working-pandas.jpg
 category: DE
 tags: [Python, Pandas, Intro]

--- a/src/content/blog/0025-pyspark_intro.mdx
+++ b/src/content/blog/0025-pyspark_intro.mdx
@@ -5,8 +5,8 @@ meta_title: Pyspark Intro
 description: Apache Spark is a very fast unified analytics engine for big data and machine learning.
   This is a beginner tutorial of how to use spark to work with dataframes.
 date: 2019-12-21
-writingDate: 2019-12-21
-updatedDate: 2019-12-24
+writing_date: 2019-12-21
+updated_date: 2019-12-24
 image: /images/blog/0025-apache-spark.jpg
 category: DE
 tags: [Python, Spark, Intro]

--- a/src/content/blog/0025-pyspark_intro.mdx
+++ b/src/content/blog/0025-pyspark_intro.mdx
@@ -5,6 +5,8 @@ meta_title: Pyspark Intro
 description: Apache Spark is a very fast unified analytics engine for big data and machine learning.
   This is a beginner tutorial of how to use spark to work with dataframes.
 date: 2019-12-21
+writingDate: 2019-12-21
+updatedDate: 2019-12-24
 image: /images/blog/0025-apache-spark.jpg
 category: DE
 tags: [Python, Spark, Intro]

--- a/src/content/blog/0026-h2o_automl.mdx
+++ b/src/content/blog/0026-h2o_automl.mdx
@@ -6,8 +6,8 @@ description: |
   H2O is a fully open source, distributed in-memory machine learning platform with linear scalability.
   In this post you will see how to use AutoML to let h2o train multiple Machine Learning algorithms automatically.
 date: 2019-12-22
-writingDate: 2019-12-22
-updatedDate: 2019-12-23
+writing_date: 2019-12-22
+updated_date: 2020-02-19
 image: /images/blog/0026-h2o.jpg
 category: AI
 tags: [Python, Spark, ML, Intro]

--- a/src/content/blog/0026-h2o_automl.mdx
+++ b/src/content/blog/0026-h2o_automl.mdx
@@ -6,6 +6,8 @@ description: |
   H2O is a fully open source, distributed in-memory machine learning platform with linear scalability.
   In this post you will see how to use AutoML to let h2o train multiple Machine Learning algorithms automatically.
 date: 2019-12-22
+writingDate: 2019-12-22
+updatedDate: 2019-12-23
 image: /images/blog/0026-h2o.jpg
 category: AI
 tags: [Python, Spark, ML, Intro]

--- a/src/content/blog/0027-databricks.mdx
+++ b/src/content/blog/0027-databricks.mdx
@@ -6,7 +6,7 @@ description: |
   Databricks provides a Unified Analytics Platform that accelerates innovation by unifying data science, engineering and business.
   Learn how to set databricks up and what it can offer you.
 date: 2019-12-23
-writingDate: 2019-12-23
+writing_date: 2019-12-23
 image: /images/blog/0027-databricks.jpg
 category: DE
 tags: [Tools, Spark]

--- a/src/content/blog/0027-databricks.mdx
+++ b/src/content/blog/0027-databricks.mdx
@@ -6,6 +6,7 @@ description: |
   Databricks provides a Unified Analytics Platform that accelerates innovation by unifying data science, engineering and business.
   Learn how to set databricks up and what it can offer you.
 date: 2019-12-23
+writingDate: 2019-12-23
 image: /images/blog/0027-databricks.jpg
 category: DE
 tags: [Tools, Spark]

--- a/src/content/blog/0028-pyspark_example.mdx
+++ b/src/content/blog/0028-pyspark_example.mdx
@@ -7,7 +7,8 @@ description: |
   This should be an example that you probably won't be able to work with pandas.
   It will give some best practices for working with data of this size.
 date: 2019-12-24
-writingDate: 2019-12-24
+writing_date: 2019-12-24
+updated_date: 2024-03-26
 image: /images/blog/0028-spark-example.jpg
 category: DE
 tags: [Python, Spark]

--- a/src/content/blog/0028-pyspark_example.mdx
+++ b/src/content/blog/0028-pyspark_example.mdx
@@ -7,6 +7,7 @@ description: |
   This should be an example that you probably won't be able to work with pandas.
   It will give some best practices for working with data of this size.
 date: 2019-12-24
+writingDate: 2019-12-24
 image: /images/blog/0028-spark-example.jpg
 category: DE
 tags: [Python, Spark]

--- a/src/content/blog/0029-luigi.mdx
+++ b/src/content/blog/0029-luigi.mdx
@@ -6,8 +6,8 @@ description: |
   Luigi is a Python package that helps you build complex pipelines of batch jobs.
   It handles dependency resolution, workflow management, visualization, handling failures, command line integration, and much more.
 date: 2020-01-06
-writingDate: 2020-01-06
-updatedDate: 2024-06-19
+writing_date: 2020-01-06
+updated_date: 2024-06-19
 image: /images/blog/0029-luigi.jpg
 category: tools
 tags: [Tools, Orchestration]

--- a/src/content/blog/0029-luigi.mdx
+++ b/src/content/blog/0029-luigi.mdx
@@ -6,6 +6,8 @@ description: |
   Luigi is a Python package that helps you build complex pipelines of batch jobs.
   It handles dependency resolution, workflow management, visualization, handling failures, command line integration, and much more.
 date: 2020-01-06
+writingDate: 2020-01-06
+updatedDate: 2024-06-19
 image: /images/blog/0029-luigi.jpg
 category: tools
 tags: [Tools, Orchestration]

--- a/src/content/blog/0030-cmder.mdx
+++ b/src/content/blog/0030-cmder.mdx
@@ -4,8 +4,8 @@ title: Cmder terminal for windows
 meta_title: Cmder terminal for windows
 description: Cmder is a really good terminal for windows that can replace the default one.
 date: 2020-02-29
-writingDate: 2020-02-29
-updatedDate: 2026-03-27
+writing_date: 2020-02-29
+updated_date: 2026-03-27
 image: /images/blog/0030-cmder.jpg
 category: tools
 tags: [Tools]

--- a/src/content/blog/0030-cmder.mdx
+++ b/src/content/blog/0030-cmder.mdx
@@ -4,6 +4,8 @@ title: Cmder terminal for windows
 meta_title: Cmder terminal for windows
 description: Cmder is a really good terminal for windows that can replace the default one.
 date: 2020-02-29
+writingDate: 2020-02-29
+updatedDate: 2026-03-27
 image: /images/blog/0030-cmder.jpg
 category: tools
 tags: [Tools]

--- a/src/content/blog/0031-poetry.mdx
+++ b/src/content/blog/0031-poetry.mdx
@@ -7,8 +7,8 @@ description: |
   It makes it really easy to manage packages while using environments under the hood.
   It also allows build and publishing packages to PyPI (or other sites).
 date: 2020-05-08
-writingDate: 2020-05-08
-updatedDate: 2020-05-16
+writing_date: 2020-05-08
+updated_date: 2020-05-16
 image: /images/blog/0031-poetry.jpg
 category: tools
 tags: [Python, Tools]

--- a/src/content/blog/0031-poetry.mdx
+++ b/src/content/blog/0031-poetry.mdx
@@ -7,6 +7,8 @@ description: |
   It makes it really easy to manage packages while using environments under the hood.
   It also allows build and publishing packages to PyPI (or other sites).
 date: 2020-05-08
+writingDate: 2020-05-08
+updatedDate: 2020-05-16
 image: /images/blog/0031-poetry.jpg
 category: tools
 tags: [Python, Tools]

--- a/src/content/blog/0032-pre_commit.mdx
+++ b/src/content/blog/0032-pre_commit.mdx
@@ -6,8 +6,8 @@ description: |
   With pre-commit you can automate some repetitive tasks before doing a commit on a git repository.
   It is useful for identifying simple issues before submission to code review.
 date: 2020-05-14
-writingDate: 2020-05-14
-updatedDate: 2020-05-20
+writing_date: 2020-05-14
+updated_date: 2020-05-20
 image: /images/blog/0032-pre-commit.jpg
 category: tools
 tags: [Tools]

--- a/src/content/blog/0032-pre_commit.mdx
+++ b/src/content/blog/0032-pre_commit.mdx
@@ -6,6 +6,8 @@ description: |
   With pre-commit you can automate some repetitive tasks before doing a commit on a git repository.
   It is useful for identifying simple issues before submission to code review.
 date: 2020-05-14
+writingDate: 2020-05-14
+updatedDate: 2020-05-20
 image: /images/blog/0032-pre-commit.jpg
 category: tools
 tags: [Tools]

--- a/src/content/blog/0033-python_environment_config.mdx
+++ b/src/content/blog/0033-python_environment_config.mdx
@@ -4,7 +4,7 @@ title: Setting up a Python environment
 meta_title: Setting up a Python environment
 description: Learn how to properly set up a python development environment with all the useful tools you can use as well as some good tips to work as a pro.
 date: 2020-05-20
-writingDate: 2020-05-20
+writing_date: 2020-05-20
 image: /images/blog/0033-python-config-panel.jpg
 category: python
 tags: [Python, Tools]

--- a/src/content/blog/0033-python_environment_config.mdx
+++ b/src/content/blog/0033-python_environment_config.mdx
@@ -4,6 +4,7 @@ title: Setting up a Python environment
 meta_title: Setting up a Python environment
 description: Learn how to properly set up a python development environment with all the useful tools you can use as well as some good tips to work as a pro.
 date: 2020-05-20
+writingDate: 2020-05-20
 image: /images/blog/0033-python-config-panel.jpg
 category: python
 tags: [Python, Tools]

--- a/src/content/blog/0034-pyspark_java_udf.mdx
+++ b/src/content/blog/0034-pyspark_java_udf.mdx
@@ -4,6 +4,8 @@ title: Java UDF with pyspark
 meta_title: Java UDF with pyspark
 description: Learn how to create and use Java UDFs with PySpark for improved performance. This guide covers setting up Java functions, compiling them, and integrating them into your PySpark workflows, with a performance comparison to Python UDFs.
 date: 2020-11-03
+writingDate: 2020-11-03
+updatedDate: 2020-11-04
 image: /images/blog/0034-java-and-spark.jpg
 category: DE
 tags: [Python, Spark, Benchmark]

--- a/src/content/blog/0034-pyspark_java_udf.mdx
+++ b/src/content/blog/0034-pyspark_java_udf.mdx
@@ -4,8 +4,8 @@ title: Java UDF with pyspark
 meta_title: Java UDF with pyspark
 description: Learn how to create and use Java UDFs with PySpark for improved performance. This guide covers setting up Java functions, compiling them, and integrating them into your PySpark workflows, with a performance comparison to Python UDFs.
 date: 2020-11-03
-writingDate: 2020-11-03
-updatedDate: 2020-11-04
+writing_date: 2020-11-03
+updated_date: 2020-11-04
 image: /images/blog/0034-java-and-spark.jpg
 category: DE
 tags: [Python, Spark, Benchmark]

--- a/src/content/blog/0035-ing_api.mdx
+++ b/src/content/blog/0035-ing_api.mdx
@@ -4,6 +4,8 @@ title: ING API with python
 meta_title: ING API with python
 description: Learn how to interact with ING's Open Banking API using Python. This guide covers setting up certificates, making authenticated requests, and integrating with the ING API to perform basic operations.
 date: 2021-03-10
+writingDate: 2021-03-10
+updatedDate: 2021-03-11
 image: /images/blog/0035-ing-lion.jpg
 category: API
 tags: [Python, DE, API]

--- a/src/content/blog/0035-ing_api.mdx
+++ b/src/content/blog/0035-ing_api.mdx
@@ -4,8 +4,8 @@ title: ING API with python
 meta_title: ING API with python
 description: Learn how to interact with ING's Open Banking API using Python. This guide covers setting up certificates, making authenticated requests, and integrating with the ING API to perform basic operations.
 date: 2021-03-10
-writingDate: 2021-03-10
-updatedDate: 2021-03-11
+writing_date: 2021-03-10
+updated_date: 2021-03-11
 image: /images/blog/0035-ing-lion.jpg
 category: API
 tags: [Python, DE, API]

--- a/src/content/blog/0036-regex.mdx
+++ b/src/content/blog/0036-regex.mdx
@@ -7,8 +7,8 @@ description: |
   It also explains how to use regex in Python, Pandas, and Amazon Redshift, offering practical examples and functions for working with text data.
   This comprehensive resource helps users understand and apply regex in various programming contexts.
 date: 2021-04-05
-writingDate: 2021-04-05
-updatedDate: 2024-03-14
+writing_date: 2021-04-05
+updated_date: 2024-03-14
 image: /images/blog/0036-regex.jpg
 category: python
 tags: [Python]

--- a/src/content/blog/0036-regex.mdx
+++ b/src/content/blog/0036-regex.mdx
@@ -7,6 +7,8 @@ description: |
   It also explains how to use regex in Python, Pandas, and Amazon Redshift, offering practical examples and functions for working with text data.
   This comprehensive resource helps users understand and apply regex in various programming contexts.
 date: 2021-04-05
+writingDate: 2021-04-05
+updatedDate: 2024-03-14
 image: /images/blog/0036-regex.jpg
 category: python
 tags: [Python]

--- a/src/content/blog/0037-reading_from_redshift.mdx
+++ b/src/content/blog/0037-reading_from_redshift.mdx
@@ -8,8 +8,8 @@ description: |
   The recommended approach is unloading data to Parquet files, and the post explains various methods for reading Parquet files into pandas dataframes using pandas, pyarrow, and pyarrow.dataset.
   The performance comparisons demonstrate the advantages of the new pyarrow.dataset introduced in pyarrow 3.0.0 for handling partitioned data efficiently.
 date: 2021-06-08
-writingDate: 2021-06-08
-updatedDate: 2024-03-14
+writing_date: 2021-06-08
+updated_date: 2024-03-14
 image: /images/blog/0037-arrow-reading-redshift-book.jpg
 category: DE
 tags: [Python, DE, SQL, AWS]

--- a/src/content/blog/0037-reading_from_redshift.mdx
+++ b/src/content/blog/0037-reading_from_redshift.mdx
@@ -8,6 +8,8 @@ description: |
   The recommended approach is unloading data to Parquet files, and the post explains various methods for reading Parquet files into pandas dataframes using pandas, pyarrow, and pyarrow.dataset.
   The performance comparisons demonstrate the advantages of the new pyarrow.dataset introduced in pyarrow 3.0.0 for handling partitioned data efficiently.
 date: 2021-06-08
+writingDate: 2021-06-08
+updatedDate: 2024-03-14
 image: /images/blog/0037-arrow-reading-redshift-book.jpg
 category: DE
 tags: [Python, DE, SQL, AWS]

--- a/src/content/blog/0038-poetry_versioning.mdx
+++ b/src/content/blog/0038-poetry_versioning.mdx
@@ -7,6 +7,8 @@ description: |
   It follows semantic versioning and recommends tools for updating versions.
   GitHub actions are set up to automatically update the version, commit changes when necessary, and tag commits on the main branch.
 date: 2023-11-07
+writingDate: 2023-11-07
+updatedDate: 2024-04-25
 image: /images/blog/0038-poetry-versioning.jpg
 category: tools
 tags: [Python, Tools, Poetry, Versioning]

--- a/src/content/blog/0038-poetry_versioning.mdx
+++ b/src/content/blog/0038-poetry_versioning.mdx
@@ -7,8 +7,8 @@ description: |
   It follows semantic versioning and recommends tools for updating versions.
   GitHub actions are set up to automatically update the version, commit changes when necessary, and tag commits on the main branch.
 date: 2023-11-07
-writingDate: 2023-11-07
-updatedDate: 2024-04-25
+writing_date: 2023-11-07
+updated_date: 2024-04-25
 image: /images/blog/0038-poetry-versioning.jpg
 category: tools
 tags: [Python, Tools, Poetry, Versioning]

--- a/src/content/blog/0039-rewrite-git-history.mdx
+++ b/src/content/blog/0039-rewrite-git-history.mdx
@@ -4,8 +4,8 @@ title: Clean repo by rewriting GIT history
 meta_title: Clean repo by rewriting GIT history
 description: Discover how to clean up your Git history effortlessly with our step-by-step guide. Learn to eliminate unnecessary commits, maintain versioning consistency, and automate the process with Python scripts. Streamline your repository and enhance collaboration today!
 date: 2024-03-17
-writingDate: 2024-03-17
-updatedDate: 2025-08-11
+writing_date: 2024-03-17
+updated_date: 2025-08-11
 image: /images/blog/0039-rewriting-history.jpg
 category: git
 tags: [GIT]

--- a/src/content/blog/0039-rewrite-git-history.mdx
+++ b/src/content/blog/0039-rewrite-git-history.mdx
@@ -4,6 +4,8 @@ title: Clean repo by rewriting GIT history
 meta_title: Clean repo by rewriting GIT history
 description: Discover how to clean up your Git history effortlessly with our step-by-step guide. Learn to eliminate unnecessary commits, maintain versioning consistency, and automate the process with Python scripts. Streamline your repository and enhance collaboration today!
 date: 2024-03-17
+writingDate: 2024-03-17
+updatedDate: 2025-08-11
 image: /images/blog/0039-rewriting-history.jpg
 category: git
 tags: [GIT]

--- a/src/content/blog/0040-prefect-essentials.mdx
+++ b/src/content/blog/0040-prefect-essentials.mdx
@@ -4,6 +4,8 @@ title: "Prefect Essentials: Basics, Setup and Migration"
 meta_title: Prefect Essentials
 description: Discover Prefect's simplicity and flexibility. Learn the basics, setup Prefect Cloud, and smoothly migrate from other orchestrators.
 date: 2024-04-08
+writingDate: 2024-04-08
+updatedDate: 2026-03-27
 image: /images/blog/0040-prefect-orchestra.jpg
 category: tools
 tags: [Tools, Orchestration, Intro, Setup]

--- a/src/content/blog/0040-prefect-essentials.mdx
+++ b/src/content/blog/0040-prefect-essentials.mdx
@@ -4,8 +4,8 @@ title: "Prefect Essentials: Basics, Setup and Migration"
 meta_title: Prefect Essentials
 description: Discover Prefect's simplicity and flexibility. Learn the basics, setup Prefect Cloud, and smoothly migrate from other orchestrators.
 date: 2024-04-08
-writingDate: 2024-04-08
-updatedDate: 2026-03-27
+writing_date: 2024-04-08
+updated_date: 2026-03-27
 image: /images/blog/0040-prefect-orchestra.jpg
 category: tools
 tags: [Tools, Orchestration, Intro, Setup]

--- a/src/content/blog/0041-prefect-server.mdx
+++ b/src/content/blog/0041-prefect-server.mdx
@@ -4,6 +4,8 @@ title: "Setting Up and Deploying Prefect Server: A Comprehensive Guide"
 meta_title: Prefect Server Setup
 description: Learn how to set up and deploy Prefect Server for orchestrating workflows seamlessly. Understand the steps involved, including server configuration, creating deployments, and connecting to the server
 date: 2024-04-11
+writingDate: 2024-04-09
+updatedDate: 2025-03-07
 image: /images/blog/0041-prefect-server.jpg
 category: tools
 tags: [Tools, Orchestration, Tutorial, Setup]

--- a/src/content/blog/0041-prefect-server.mdx
+++ b/src/content/blog/0041-prefect-server.mdx
@@ -4,8 +4,8 @@ title: "Setting Up and Deploying Prefect Server: A Comprehensive Guide"
 meta_title: Prefect Server Setup
 description: Learn how to set up and deploy Prefect Server for orchestrating workflows seamlessly. Understand the steps involved, including server configuration, creating deployments, and connecting to the server
 date: 2024-04-11
-writingDate: 2024-04-09
-updatedDate: 2025-03-07
+writing_date: 2024-04-09
+updated_date: 2025-03-07
 image: /images/blog/0041-prefect-server.jpg
 category: tools
 tags: [Tools, Orchestration, Tutorial, Setup]

--- a/src/content/blog/0042-emr.mdx
+++ b/src/content/blog/0042-emr.mdx
@@ -7,8 +7,8 @@ description: |
   From running scripts to handling parameters and using Docker, we cover it all.
   With practical examples and clear explanations, simplify your PySpark workflow on EMR and make big data processing a breeze!
 date: 2024-05-07
-writingDate: 2024-04-25
-updatedDate: 2024-05-27
+writing_date: 2024-04-25
+updated_date: 2024-05-27
 image: /images/blog/0042-interconected-cabins.jpg
 category: cloud_devops
 tags: [AWS, Tutorial]

--- a/src/content/blog/0042-emr.mdx
+++ b/src/content/blog/0042-emr.mdx
@@ -7,6 +7,8 @@ description: |
   From running scripts to handling parameters and using Docker, we cover it all.
   With practical examples and clear explanations, simplify your PySpark workflow on EMR and make big data processing a breeze!
 date: 2024-05-07
+writingDate: 2024-04-25
+updatedDate: 2024-05-27
 image: /images/blog/0042-interconected-cabins.jpg
 category: cloud_devops
 tags: [AWS, Tutorial]

--- a/src/content/blog/0043-self-healing-pipelines.mdx
+++ b/src/content/blog/0043-self-healing-pipelines.mdx
@@ -4,7 +4,7 @@ title: Self-Healing Pipelines
 meta_title: Self-Healing Pipelines
 description: This post explores self-healing pipelines, which automate backfilling missing data to reduce manual interventions. It discusses challenges in traditional batch processing and introduces techniques like partitioning, deduplication, and schema change handling. Detailed Python and SQL code snippets illustrate implementation, emphasizing the importance of proper setup in dbt.
 date: 2024-05-23
-writingDate: 2024-05-07
+writing_date: 2024-05-07
 image: /images/blog/0043-self-healing-pipelines-industrial.jpg
 category: DE
 tags: [DE, Best Practices]

--- a/src/content/blog/0043-self-healing-pipelines.mdx
+++ b/src/content/blog/0043-self-healing-pipelines.mdx
@@ -4,6 +4,7 @@ title: Self-Healing Pipelines
 meta_title: Self-Healing Pipelines
 description: This post explores self-healing pipelines, which automate backfilling missing data to reduce manual interventions. It discusses challenges in traditional batch processing and introduces techniques like partitioning, deduplication, and schema change handling. Detailed Python and SQL code snippets illustrate implementation, emphasizing the importance of proper setup in dbt.
 date: 2024-05-23
+writingDate: 2024-05-07
 image: /images/blog/0043-self-healing-pipelines-industrial.jpg
 category: DE
 tags: [DE, Best Practices]

--- a/src/content/blog/0044-running-dbt.mdx
+++ b/src/content/blog/0044-running-dbt.mdx
@@ -4,6 +4,8 @@ title: Running dbt with AWS ECS (Fargate)
 meta_title: Running dbt with AWS ECS
 description: Guide to setting up and running dbt on AWS ECS (Fargate), covering Dockerization, package handling, Docker images, integration with Prefect and exporting results.
 date: 2024-06-07
+writingDate: 2024-05-15
+updatedDate: 2025-08-11
 image: /images/blog/0044-running-dbt-fargate.jpg
 category: DE
 tags: [SQL, DE, AWS, Setup, Tutorial, dbt]

--- a/src/content/blog/0044-running-dbt.mdx
+++ b/src/content/blog/0044-running-dbt.mdx
@@ -4,8 +4,8 @@ title: Running dbt with AWS ECS (Fargate)
 meta_title: Running dbt with AWS ECS
 description: Guide to setting up and running dbt on AWS ECS (Fargate), covering Dockerization, package handling, Docker images, integration with Prefect and exporting results.
 date: 2024-06-07
-writingDate: 2024-05-15
-updatedDate: 2025-08-11
+writing_date: 2024-05-15
+updated_date: 2025-08-11
 image: /images/blog/0044-running-dbt-fargate.jpg
 category: DE
 tags: [SQL, DE, AWS, Setup, Tutorial, dbt]

--- a/src/content/blog/0045-dbt-testing.mdx
+++ b/src/content/blog/0045-dbt-testing.mdx
@@ -4,6 +4,8 @@ title: dbt testing with DuckDB
 meta_title: dbt testing with DuckDB
 description: Learn how to test dbt projects using DuckDB to ensure high-quality, consistent SQL code. This guide covers setting up a SQL linter with Sqlfluff, automating testing with pre-commit hooks, and creating a streamlined CI pipeline for efficient testing.
 date: 2024-06-19
+writingDate: 2024-06-05
+updatedDate: 2025-08-11
 image: /images/blog/0045-dbt-testing-duckdb.jpg
 category: DE
 tags: [SQL, DE, Best Practices, dbt]

--- a/src/content/blog/0045-dbt-testing.mdx
+++ b/src/content/blog/0045-dbt-testing.mdx
@@ -4,8 +4,8 @@ title: dbt testing with DuckDB
 meta_title: dbt testing with DuckDB
 description: Learn how to test dbt projects using DuckDB to ensure high-quality, consistent SQL code. This guide covers setting up a SQL linter with Sqlfluff, automating testing with pre-commit hooks, and creating a streamlined CI pipeline for efficient testing.
 date: 2024-06-19
-writingDate: 2024-06-05
-updatedDate: 2025-08-11
+writing_date: 2024-06-05
+updated_date: 2025-08-11
 image: /images/blog/0045-dbt-testing-duckdb.jpg
 category: DE
 tags: [SQL, DE, Best Practices, dbt]

--- a/src/content/blog/0046-salesforce.mdx
+++ b/src/content/blog/0046-salesforce.mdx
@@ -4,6 +4,8 @@ title: Extracting data from Salesforce with Python
 meta_title: Extracting data from Salesforce
 description: The post serves as a comprehensive guide to extracting data from Salesforce using Python, focusing on the Simple Salesforce library. It covers various querying options, strategies to avoid timeouts and memory errors, and insights into different types of fields within Salesforce. Additionally, it provides practical code examples and recommendations for effective data extraction.
 date: 2024-07-16
+writingDate: 2024-05-27
+updatedDate: 2025-01-29
 image: /images/blog/0046-celestial-salesforce.jpg
 category: DE
 tags: [Python, DE, Tutorial]

--- a/src/content/blog/0046-salesforce.mdx
+++ b/src/content/blog/0046-salesforce.mdx
@@ -4,8 +4,8 @@ title: Extracting data from Salesforce with Python
 meta_title: Extracting data from Salesforce
 description: The post serves as a comprehensive guide to extracting data from Salesforce using Python, focusing on the Simple Salesforce library. It covers various querying options, strategies to avoid timeouts and memory errors, and insights into different types of fields within Salesforce. Additionally, it provides practical code examples and recommendations for effective data extraction.
 date: 2024-07-16
-writingDate: 2024-05-27
-updatedDate: 2025-01-29
+writing_date: 2024-05-27
+updated_date: 2025-01-29
 image: /images/blog/0046-celestial-salesforce.jpg
 category: DE
 tags: [Python, DE, Tutorial]

--- a/src/content/blog/0047-install_windows.mdx
+++ b/src/content/blog/0047-install_windows.mdx
@@ -4,6 +4,8 @@ title: "How to Perform a Clean Windows Installation: A Step-by-Step Guide"
 meta_title: How to Perform a Clean Windows Installation
 description: Learn how to download, install, and set up a clean Windows installation without bloatware. This comprehensive guide covers creating a bootable USB, setting up a local account, and configuring essential settings for optimal performance.
 date: 2024-08-14
+writingDate: 2024-06-19
+updatedDate: 2024-11-17
 image: /images/blog/0047-desk-with-windows.jpg
 category: others
 tags: [Tutorial, Setup, Windows]

--- a/src/content/blog/0047-install_windows.mdx
+++ b/src/content/blog/0047-install_windows.mdx
@@ -4,8 +4,8 @@ title: "How to Perform a Clean Windows Installation: A Step-by-Step Guide"
 meta_title: How to Perform a Clean Windows Installation
 description: Learn how to download, install, and set up a clean Windows installation without bloatware. This comprehensive guide covers creating a bootable USB, setting up a local account, and configuring essential settings for optimal performance.
 date: 2024-08-14
-writingDate: 2024-06-19
-updatedDate: 2024-11-17
+writing_date: 2024-06-19
+updated_date: 2024-11-17
 image: /images/blog/0047-desk-with-windows.jpg
 category: others
 tags: [Tutorial, Setup, Windows]

--- a/src/content/blog/0048-calls-open-ai.mdx
+++ b/src/content/blog/0048-calls-open-ai.mdx
@@ -4,7 +4,8 @@ title: Transcribing Audios with Whisper and Structuring Data with ChatGPT
 meta_title: Transcribing Audios with Whisper and Structuring Data with ChatGPT
 description: Learn how to extract and analyze call data using OpenAI models, with a focus on structured outputs for clear and consistent results. This guide covers transcribing calls with Whisper, extracting insights with ChatGPT, handling invalid calls, and processing multiple files efficiently. Explore how to use Pydantic models and OpenAI's API for structured data extraction.
 date: 2024-09-02
-writingDate: 2024-06-21
+writing_date: 2024-06-21
+updated_date: 2025-04-10
 image: /images/blog/0048-process-calls-openai.jpg
 category: AI
 tags: [Python, DE, AI, Tutorial, OpenAI]

--- a/src/content/blog/0048-calls-open-ai.mdx
+++ b/src/content/blog/0048-calls-open-ai.mdx
@@ -4,6 +4,7 @@ title: Transcribing Audios with Whisper and Structuring Data with ChatGPT
 meta_title: Transcribing Audios with Whisper and Structuring Data with ChatGPT
 description: Learn how to extract and analyze call data using OpenAI models, with a focus on structured outputs for clear and consistent results. This guide covers transcribing calls with Whisper, extracting insights with ChatGPT, handling invalid calls, and processing multiple files efficiently. Explore how to use Pydantic models and OpenAI's API for structured data extraction.
 date: 2024-09-02
+writingDate: 2024-06-21
 image: /images/blog/0048-process-calls-openai.jpg
 category: AI
 tags: [Python, DE, AI, Tutorial, OpenAI]

--- a/src/content/blog/0049-open-ai-async.mdx
+++ b/src/content/blog/0049-open-ai-async.mdx
@@ -4,6 +4,8 @@ title: Concurrent Async Calls to OpenAI with Rate Limiting
 meta_title: How to Handle Concurrent OpenAI API Calls with Rate Limiting
 description: Learn how to implement multiple concurrent async calls to the OpenAI API while managing quota limits effectively using a rate limiter in Python. This guide covers best practices for API management in data engineering.
 date: 2024-09-25
+writingDate: 2024-08-23
+updatedDate: 2024-10-24
 image: /images/blog/0049-Async-calls-with-rate-limiter.jpg
 category: AI
 tags: [API, Best Practices, DE, OpenAI, Python]

--- a/src/content/blog/0049-open-ai-async.mdx
+++ b/src/content/blog/0049-open-ai-async.mdx
@@ -4,8 +4,8 @@ title: Concurrent Async Calls to OpenAI with Rate Limiting
 meta_title: How to Handle Concurrent OpenAI API Calls with Rate Limiting
 description: Learn how to implement multiple concurrent async calls to the OpenAI API while managing quota limits effectively using a rate limiter in Python. This guide covers best practices for API management in data engineering.
 date: 2024-09-25
-writingDate: 2024-08-23
-updatedDate: 2024-10-24
+writing_date: 2024-08-23
+updated_date: 2024-10-24
 image: /images/blog/0049-Async-calls-with-rate-limiter.jpg
 category: AI
 tags: [API, Best Practices, DE, OpenAI, Python]

--- a/src/content/blog/0050-small_files.mdx
+++ b/src/content/blog/0050-small_files.mdx
@@ -4,6 +4,8 @@ title: Solving the problem with small files in the Data Lake
 meta_title: Solving the problem with small files in the Data Lake
 description: This post addresses the common problem of small files in data lakes, which can lead to significant performance degradation and increased costs. It provides an in-depth guide on understanding the issues caused by small files, determining optimal file sizes, and effectively managing file sizes using tools like Apache Spark, AWS Athena, Delta Lake, and Apache Iceberg. The post also covers strategies for tracking file sizes and partitioning tables to optimize data processing and storage efficiency.
 date: 2024-10-23
+writingDate: 2024-07-05
+updatedDate: 2026-05-05
 image: /images/blog/0050-melting-small-files-cauldron.jpg
 category: DE
 tags: [DE, Performance, Spark, dbt]

--- a/src/content/blog/0050-small_files.mdx
+++ b/src/content/blog/0050-small_files.mdx
@@ -4,8 +4,8 @@ title: Solving the problem with small files in the Data Lake
 meta_title: Solving the problem with small files in the Data Lake
 description: This post addresses the common problem of small files in data lakes, which can lead to significant performance degradation and increased costs. It provides an in-depth guide on understanding the issues caused by small files, determining optimal file sizes, and effectively managing file sizes using tools like Apache Spark, AWS Athena, Delta Lake, and Apache Iceberg. The post also covers strategies for tracking file sizes and partitioning tables to optimize data processing and storage efficiency.
 date: 2024-10-23
-writingDate: 2024-07-05
-updatedDate: 2026-05-05
+writing_date: 2024-07-05
+updated_date: 2026-05-05
 image: /images/blog/0050-melting-small-files-cauldron.jpg
 category: DE
 tags: [DE, Performance, Spark, dbt]

--- a/src/content/blog/0051-amd-tdp.mdx
+++ b/src/content/blog/0051-amd-tdp.mdx
@@ -4,6 +4,8 @@ title: How to Control AMD CPU Temperatures
 meta_title: Managing AMD CPU Temperatures Automatically at Startup
 description: Learn how to control your AMD CPU's temperatures by configuring TDP limits to apply automatically at startup using Task Scheduler in Windows.
 date: 2024-11-29
+writingDate: 2024-07-18
+updatedDate: 2025-09-25
 image: /images/blog/0051-motherboard-amd-tdp.jpg
 category: others
 tags: [Tutorial, Setup, Performance, Windows]

--- a/src/content/blog/0051-amd-tdp.mdx
+++ b/src/content/blog/0051-amd-tdp.mdx
@@ -4,8 +4,8 @@ title: How to Control AMD CPU Temperatures
 meta_title: Managing AMD CPU Temperatures Automatically at Startup
 description: Learn how to control your AMD CPU's temperatures by configuring TDP limits to apply automatically at startup using Task Scheduler in Windows.
 date: 2024-11-29
-writingDate: 2024-07-18
-updatedDate: 2025-09-25
+writing_date: 2024-07-18
+updated_date: 2025-09-25
 image: /images/blog/0051-motherboard-amd-tdp.jpg
 category: others
 tags: [Tutorial, Setup, Performance, Windows]

--- a/src/content/blog/0052-terramaster-nas.mdx
+++ b/src/content/blog/0052-terramaster-nas.mdx
@@ -4,6 +4,8 @@ title: Setting Up and Optimizing a Terramaster NAS
 meta_title: Complete Guide to Setting Up a Terramaster NAS
 description: A comprehensive guide on setting up and configuring the Terramaster F2-424 NAS, including hardware selection, RAID setup, storage configuration, network optimization, and essential app installations.
 date: 2024-12-21
+writingDate: 2024-11-04
+updatedDate: 2025-05-05
 image: /images/blog/0052-terramaster.jpg
 category: hardware
 tags: [NAS, Hardware, Terramaster]

--- a/src/content/blog/0052-terramaster-nas.mdx
+++ b/src/content/blog/0052-terramaster-nas.mdx
@@ -4,8 +4,8 @@ title: Setting Up and Optimizing a Terramaster NAS
 meta_title: Complete Guide to Setting Up a Terramaster NAS
 description: A comprehensive guide on setting up and configuring the Terramaster F2-424 NAS, including hardware selection, RAID setup, storage configuration, network optimization, and essential app installations.
 date: 2024-12-21
-writingDate: 2024-11-04
-updatedDate: 2025-05-05
+writing_date: 2024-11-04
+updated_date: 2025-05-05
 image: /images/blog/0052-terramaster.jpg
 category: hardware
 tags: [NAS, Hardware, Terramaster]

--- a/src/content/blog/0053-terramaster-mega.mdx
+++ b/src/content/blog/0053-terramaster-mega.mdx
@@ -4,8 +4,8 @@ title: How to Set Up MEGASync on a TerraMaster NAS Using Docker
 meta_title: MEGASync Setup on TerraMaster NAS with Docker
 description: A step-by-step guide to installing and configuring MEGASync on a TerraMaster NAS using Docker for seamless MEGA cloud synchronization.
 date: 2025-01-15
-writingDate: 2024-12-22
-updatedDate: 2025-05-05
+writing_date: 2024-12-22
+updated_date: 2025-05-05
 image: /images/blog/0053-terramaster-ship-mega-planet.jpg
 category: hardware
 tags: [NAS, Hardware, Terramaster, Docker]

--- a/src/content/blog/0053-terramaster-mega.mdx
+++ b/src/content/blog/0053-terramaster-mega.mdx
@@ -4,6 +4,8 @@ title: How to Set Up MEGASync on a TerraMaster NAS Using Docker
 meta_title: MEGASync Setup on TerraMaster NAS with Docker
 description: A step-by-step guide to installing and configuring MEGASync on a TerraMaster NAS using Docker for seamless MEGA cloud synchronization.
 date: 2025-01-15
+writingDate: 2024-12-22
+updatedDate: 2025-05-05
 image: /images/blog/0053-terramaster-ship-mega-planet.jpg
 category: hardware
 tags: [NAS, Hardware, Terramaster, Docker]

--- a/src/content/blog/0054-s3-costs.mdx
+++ b/src/content/blog/0054-s3-costs.mdx
@@ -4,6 +4,7 @@ title: Managing S3 Costs with Inventory and Lifecycle Policies
 meta_title: Manage S3 Costs with Inventory and Lifecycle Policies
 description: Discover strategies to optimize Amazon S3 costs by leveraging inventory exports and lifecycle policies for automated storage management.
 date: 2025-02-28
+writingDate: 2025-01-15
 image: /images/blog/0054-s3-costs.jpg
 category: cloud_devops
 tags: [AWS, S3, Best Practices]

--- a/src/content/blog/0054-s3-costs.mdx
+++ b/src/content/blog/0054-s3-costs.mdx
@@ -4,7 +4,7 @@ title: Managing S3 Costs with Inventory and Lifecycle Policies
 meta_title: Manage S3 Costs with Inventory and Lifecycle Policies
 description: Discover strategies to optimize Amazon S3 costs by leveraging inventory exports and lifecycle policies for automated storage management.
 date: 2025-02-28
-writingDate: 2025-01-15
+writing_date: 2025-01-15
 image: /images/blog/0054-s3-costs.jpg
 category: cloud_devops
 tags: [AWS, S3, Best Practices]

--- a/src/content/blog/0055-astral-uv-ruff.mdx
+++ b/src/content/blog/0055-astral-uv-ruff.mdx
@@ -4,8 +4,8 @@ title: Fast Python Package Management and Linting with uv and ruff
 meta_title: "uv and ruff: Fast Python Package Management and Linting"
 description: Discover how Astral's Rust-powered tools, uv and ruff, provide a blazing-fast alternative for Python package management and linting. Learn how to set them up, integrate them into CI/CD workflows, and boost your development speed.
 date: 2025-03-14
-writingDate: 2025-03-07
-updatedDate: 2025-04-04
+writing_date: 2025-03-07
+updated_date: 2025-04-04
 image: /images/blog/0055-astral.jpg
 category: python
 tags: [Python, Tools, Performance, Benchmark, Setup, Best Practices]

--- a/src/content/blog/0055-astral-uv-ruff.mdx
+++ b/src/content/blog/0055-astral-uv-ruff.mdx
@@ -4,6 +4,8 @@ title: Fast Python Package Management and Linting with uv and ruff
 meta_title: "uv and ruff: Fast Python Package Management and Linting"
 description: Discover how Astral's Rust-powered tools, uv and ruff, provide a blazing-fast alternative for Python package management and linting. Learn how to set them up, integrate them into CI/CD workflows, and boost your development speed.
 date: 2025-03-14
+writingDate: 2025-03-07
+updatedDate: 2025-04-04
 image: /images/blog/0055-astral.jpg
 category: python
 tags: [Python, Tools, Performance, Benchmark, Setup, Best Practices]

--- a/src/content/blog/0056-glue-versions.mdx
+++ b/src/content/blog/0056-glue-versions.mdx
@@ -4,6 +4,8 @@ title: Improving Athena performance by reducing Glue versions
 meta_title: Fixing dbt Athena Failures and Speed Issues by Reducing Glue Schema Versions
 description: Learn how AWS Glue schema version limits can silently break Athena queries and dbt runs—and how cleaning up old versions can improve performance by up to 4×.
 date: 2025-04-10
+writingDate: 2025-04-10
+updatedDate: 2025-04-11
 image: /images/blog/0056-athenea.jpg
 category: DE
 tags: [DE, AWS, Best Practices, Performance, dbt]

--- a/src/content/blog/0056-glue-versions.mdx
+++ b/src/content/blog/0056-glue-versions.mdx
@@ -4,8 +4,8 @@ title: Improving Athena performance by reducing Glue versions
 meta_title: Fixing dbt Athena Failures and Speed Issues by Reducing Glue Schema Versions
 description: Learn how AWS Glue schema version limits can silently break Athena queries and dbt runs—and how cleaning up old versions can improve performance by up to 4×.
 date: 2025-04-10
-writingDate: 2025-04-10
-updatedDate: 2025-04-11
+writing_date: 2025-04-10
+updated_date: 2025-04-11
 image: /images/blog/0056-athenea.jpg
 category: DE
 tags: [DE, AWS, Best Practices, Performance, dbt]

--- a/src/content/blog/0057-smoothing.mdx
+++ b/src/content/blog/0057-smoothing.mdx
@@ -4,7 +4,7 @@ title: Time Series Smoothing Techniques in Python and SQL
 meta_title: Time Series Smoothing Techniques in Python and SQL
 description: A practical guide to smoothing time series data using Python and SQL. Explore moving averages, Gaussian and Lowess smoothers, SQL medians, quantiles, and their trade-offs through side-by-side visual comparisons.
 date: 2025-05-08
-writingDate: 2025-04-04
+writing_date: 2025-04-04
 image: /images/blog/0057-smoothie-curtains.jpg
 category: DE
 tags: [DE, Python, SQL, Best Practices]

--- a/src/content/blog/0057-smoothing.mdx
+++ b/src/content/blog/0057-smoothing.mdx
@@ -4,6 +4,7 @@ title: Time Series Smoothing Techniques in Python and SQL
 meta_title: Time Series Smoothing Techniques in Python and SQL
 description: A practical guide to smoothing time series data using Python and SQL. Explore moving averages, Gaussian and Lowess smoothers, SQL medians, quantiles, and their trade-offs through side-by-side visual comparisons.
 date: 2025-05-08
+writingDate: 2025-04-04
 image: /images/blog/0057-smoothie-curtains.jpg
 category: DE
 tags: [DE, Python, SQL, Best Practices]

--- a/src/content/blog/0058-pipeline-failures.mdx
+++ b/src/content/blog/0058-pipeline-failures.mdx
@@ -4,6 +4,8 @@ title: Handling pipeline failures
 meta_title: How to Handle Failures in Modern Data Pipelines
 description: Learn how to make your data pipelines resilient by design using the ETU (Extract, Transform, Upload) approach. This guide covers failure handling strategies in dbt, Prefect, and more.
 date: 2025-06-12
+writingDate: 2025-05-14
+updatedDate: 2025-08-08
 image: /images/blog/0058-hero-handling-failure.jpg
 category: DE
 tags: [SQL, DE, Best Practices, dbt, Prefect]

--- a/src/content/blog/0058-pipeline-failures.mdx
+++ b/src/content/blog/0058-pipeline-failures.mdx
@@ -4,8 +4,8 @@ title: Handling pipeline failures
 meta_title: How to Handle Failures in Modern Data Pipelines
 description: Learn how to make your data pipelines resilient by design using the ETU (Extract, Transform, Upload) approach. This guide covers failure handling strategies in dbt, Prefect, and more.
 date: 2025-06-12
-writingDate: 2025-05-14
-updatedDate: 2025-08-08
+writing_date: 2025-05-14
+updated_date: 2025-08-08
 image: /images/blog/0058-hero-handling-failure.jpg
 category: DE
 tags: [SQL, DE, Best Practices, dbt, Prefect]

--- a/src/content/blog/0059-vpn-tailscale.mdx
+++ b/src/content/blog/0059-vpn-tailscale.mdx
@@ -4,7 +4,7 @@ title: Understanding VPNs - Privacy and Security
 meta_title: Understanding VPNs - Privacy and Security
 description: "Explore the differences between commercial VPNs for privacy and security and private network VPNs for secure remote access. Learn how Tailscale simplifies private VPN setups and how exit nodes can help bypass restrictions."
 date: 2025-08-08
-writingDate: 2025-03-20
+writing_date: 2025-03-20
 image: /images/blog/0059-meshed-orbe-of-light.jpg
 category: tools
 tags: [Tools, Setup, Security, Networking]

--- a/src/content/blog/0059-vpn-tailscale.mdx
+++ b/src/content/blog/0059-vpn-tailscale.mdx
@@ -4,6 +4,7 @@ title: Understanding VPNs - Privacy and Security
 meta_title: Understanding VPNs - Privacy and Security
 description: "Explore the differences between commercial VPNs for privacy and security and private network VPNs for secure remote access. Learn how Tailscale simplifies private VPN setups and how exit nodes can help bypass restrictions."
 date: 2025-08-08
+writingDate: 2025-03-20
 image: /images/blog/0059-meshed-orbe-of-light.jpg
 category: tools
 tags: [Tools, Setup, Security, Networking]

--- a/src/content/blog/0060-duckdb.mdx
+++ b/src/content/blog/0060-duckdb.mdx
@@ -4,8 +4,8 @@ title: DuckDB and Beyond
 meta_title: DuckDB and Beyond - Fast SQL Analytics on Your Laptop
 description: "DuckDB is the “SQLite for analytics”: fast, modern SQL, and capable of billions of rows on a laptop. Learn its SQL superpowers, explore practical use cases, and discover the promise of DuckLake."
 date: 2025-09-15
-writingDate: 2025-08-24
-updatedDate: 2025-09-23
+writing_date: 2025-08-24
+updated_date: 2025-09-23
 image: /images/blog/0060-duckdb.jpg
 category: tools
 tags: [Python, SQL, DE]

--- a/src/content/blog/0060-duckdb.mdx
+++ b/src/content/blog/0060-duckdb.mdx
@@ -4,6 +4,8 @@ title: DuckDB and Beyond
 meta_title: DuckDB and Beyond - Fast SQL Analytics on Your Laptop
 description: "DuckDB is the “SQLite for analytics”: fast, modern SQL, and capable of billions of rows on a laptop. Learn its SQL superpowers, explore practical use cases, and discover the promise of DuckLake."
 date: 2025-09-15
+writingDate: 2025-08-24
+updatedDate: 2025-09-23
 image: /images/blog/0060-duckdb.jpg
 category: tools
 tags: [Python, SQL, DE]

--- a/src/content/blog/0061-apis-best-practices.mdx
+++ b/src/content/blog/0061-apis-best-practices.mdx
@@ -4,7 +4,7 @@ title: Querying APIs Best Practices
 meta_title: Querying APIs Best Practices in Python - Reliable and Efficient Clients
 description: "Learn proven best practices for building resilient Python API clients: structure, safety, error handling, and advanced patterns like streaming and incremental loads."
 date: 2025-10-14
-writing_date: 2025-10-14
+writing_date: 2025-09-17
 updated_date: 2025-11-07
 image: /images/blog/0061-api-rivers.jpg
 category: API

--- a/src/content/blog/0061-apis-best-practices.mdx
+++ b/src/content/blog/0061-apis-best-practices.mdx
@@ -4,6 +4,8 @@ title: Querying APIs Best Practices
 meta_title: Querying APIs Best Practices in Python - Reliable and Efficient Clients
 description: "Learn proven best practices for building resilient Python API clients: structure, safety, error handling, and advanced patterns like streaming and incremental loads."
 date: 2025-10-14
+writingDate: 2025-10-14
+updatedDate: 2025-11-07
 image: /images/blog/0061-api-rivers.jpg
 category: API
 tags: [Python, API, DE, Best Practices]

--- a/src/content/blog/0061-apis-best-practices.mdx
+++ b/src/content/blog/0061-apis-best-practices.mdx
@@ -4,8 +4,8 @@ title: Querying APIs Best Practices
 meta_title: Querying APIs Best Practices in Python - Reliable and Efficient Clients
 description: "Learn proven best practices for building resilient Python API clients: structure, safety, error handling, and advanced patterns like streaming and incremental loads."
 date: 2025-10-14
-writingDate: 2025-10-14
-updatedDate: 2025-11-07
+writing_date: 2025-10-14
+updated_date: 2025-11-07
 image: /images/blog/0061-api-rivers.jpg
 category: API
 tags: [Python, API, DE, Best Practices]

--- a/src/content/blog/0062-ecs.mdx
+++ b/src/content/blog/0062-ecs.mdx
@@ -4,6 +4,7 @@ title: Fast and Reproducible Python Deployments on ECS with uv
 meta_title: How to Run Python on AWS ECS the Smart Way (with uv and S3)
 description: Speed up ECS tasks with lightweight Docker images and versioned Python environments using uv. Learn how to build once, run anywhere with zero rebuilds and instant cold starts.
 date: 2025-11-25
+writingDate: 2025-10-24
 image: /images/blog/0062-ship-python-containers.jpg
 category: cloud_devops
 tags: [AWS, ECS, Docker, uv, DE, Fargate]

--- a/src/content/blog/0062-ecs.mdx
+++ b/src/content/blog/0062-ecs.mdx
@@ -4,7 +4,7 @@ title: Fast and Reproducible Python Deployments on ECS with uv
 meta_title: How to Run Python on AWS ECS the Smart Way (with uv and S3)
 description: Speed up ECS tasks with lightweight Docker images and versioned Python environments using uv. Learn how to build once, run anywhere with zero rebuilds and instant cold starts.
 date: 2025-11-25
-writingDate: 2025-10-24
+writing_date: 2025-10-24
 image: /images/blog/0062-ship-python-containers.jpg
 category: cloud_devops
 tags: [AWS, ECS, Docker, uv, DE, Fargate]

--- a/src/content/blog/0063-monorepo_multimage.mdx
+++ b/src/content/blog/0063-monorepo_multimage.mdx
@@ -4,7 +4,7 @@ title: Scaling ECS Python Deployments with a Modular Monorepo
 meta_title: Modular Python Monorepo for Scalable ECS Deployments
 description: Learn how to evolve a Python project from a single workspace to a scalable, multi-package monorepo with isolated builds, targeted CI, and lightweight ECS deployments using uv.
 date: 2025-12-09
-writingDate: 2025-11-11
+writing_date: 2025-11-11
 image: /images/blog/0063-factory-line-packages.jpg
 category: cloud_devops
 tags: [AWS, ECS, Docker, uv, DE, Fargate, Monorepo]

--- a/src/content/blog/0063-monorepo_multimage.mdx
+++ b/src/content/blog/0063-monorepo_multimage.mdx
@@ -4,6 +4,7 @@ title: Scaling ECS Python Deployments with a Modular Monorepo
 meta_title: Modular Python Monorepo for Scalable ECS Deployments
 description: Learn how to evolve a Python project from a single workspace to a scalable, multi-package monorepo with isolated builds, targeted CI, and lightweight ECS deployments using uv.
 date: 2025-12-09
+writingDate: 2025-11-11
 image: /images/blog/0063-factory-line-packages.jpg
 category: cloud_devops
 tags: [AWS, ECS, Docker, uv, DE, Fargate, Monorepo]

--- a/src/content/blog/0064-github_hooks.mdx
+++ b/src/content/blog/0064-github_hooks.mdx
@@ -4,6 +4,7 @@ title: Scalable GitHub Actions for Modern Repos
 meta_title: Scalable GitHub Actions for Modern Repos
 description: Learn how to build scalable GitHub Actions pipelines using reusable hooks, matrix jobs, gate checks, and concurrency for cleaner, faster, and more maintainable CI/CD workflows.
 date: 2026-01-14
+writingDate: 2025-11-11
 image: /images/blog/0064-octopus-hooks.jpg
 category: cloud_devops
 tags: [CI/CD, GitHub, Python, Best Practices, Monorepo]

--- a/src/content/blog/0064-github_hooks.mdx
+++ b/src/content/blog/0064-github_hooks.mdx
@@ -4,7 +4,7 @@ title: Scalable GitHub Actions for Modern Repos
 meta_title: Scalable GitHub Actions for Modern Repos
 description: Learn how to build scalable GitHub Actions pipelines using reusable hooks, matrix jobs, gate checks, and concurrency for cleaner, faster, and more maintainable CI/CD workflows.
 date: 2026-01-14
-writingDate: 2025-11-11
+writing_date: 2025-11-11
 image: /images/blog/0064-octopus-hooks.jpg
 category: cloud_devops
 tags: [CI/CD, GitHub, Python, Best Practices, Monorepo]

--- a/src/content/blog/0065-protecting-prod-tables.mdx
+++ b/src/content/blog/0065-protecting-prod-tables.mdx
@@ -4,7 +4,7 @@ title: Protecting Production Tables in dbt
 meta_title: Protecting Production Tables in dbt - Strategies for Data Quality and Security
 description: "Learn three proven strategies to safeguard production tables in dbt: protecting against bad data, preventing unexpected changes, and securing sensitive data with seeds."
 date: 2026-02-17
-writingDate: 2025-09-05
+writing_date: 2025-09-05
 image: /images/blog/0065-greek-protecting-soldiers.jpg
 category: DE
 tags: [dbt, SQL, DE]

--- a/src/content/blog/0065-protecting-prod-tables.mdx
+++ b/src/content/blog/0065-protecting-prod-tables.mdx
@@ -4,6 +4,7 @@ title: Protecting Production Tables in dbt
 meta_title: Protecting Production Tables in dbt - Strategies for Data Quality and Security
 description: "Learn three proven strategies to safeguard production tables in dbt: protecting against bad data, preventing unexpected changes, and securing sensitive data with seeds."
 date: 2026-02-17
+writingDate: 2025-09-05
 image: /images/blog/0065-greek-protecting-soldiers.jpg
 category: DE
 tags: [dbt, SQL, DE]

--- a/src/content/blog/0066-recover_s3_files.mdx
+++ b/src/content/blog/0066-recover_s3_files.mdx
@@ -4,8 +4,8 @@ title: Recovering files from S3 using Delete Markers
 meta_title: Recover deleted S3 files safely with Versioning and Delete Markers
 description: Learn how to recover accidentally deleted S3 files using versioning and delete markers — including listing deleted objects, filtering by time window, and restoring them with boto3 and pandas.
 date: 2026-03-17
-writingDate: 2025-11-04
-updatedDate: 2026-03-27
+writing_date: 2025-11-04
+updated_date: 2026-03-27
 image: /images/blog/0066-recycle-plant.jpg
 category: DE
 tags: [DE, AWS, S3, Python, Best Practices, Versioning]

--- a/src/content/blog/0066-recover_s3_files.mdx
+++ b/src/content/blog/0066-recover_s3_files.mdx
@@ -4,6 +4,8 @@ title: Recovering files from S3 using Delete Markers
 meta_title: Recover deleted S3 files safely with Versioning and Delete Markers
 description: Learn how to recover accidentally deleted S3 files using versioning and delete markers — including listing deleted objects, filtering by time window, and restoring them with boto3 and pandas.
 date: 2026-03-17
+writingDate: 2025-11-04
+updatedDate: 2026-03-27
 image: /images/blog/0066-recycle-plant.jpg
 category: DE
 tags: [DE, AWS, S3, Python, Best Practices, Versioning]

--- a/src/content/blog/0067-marimo-notebooks.mdx
+++ b/src/content/blog/0067-marimo-notebooks.mdx
@@ -4,6 +4,7 @@ title: Marimo notebooks for Python projects
 meta_title: Marimo notebooks for Python projects
 description: Why marimo is an interesting notebook alternative for Python projects.
 date: 2026-04-15
+writingDate: 2026-03-27
 image: /images/blog/0067-marimo.jpg
 category: tools
 tags: [Python, Tools, AWS, DE]

--- a/src/content/blog/0067-marimo-notebooks.mdx
+++ b/src/content/blog/0067-marimo-notebooks.mdx
@@ -4,7 +4,7 @@ title: Marimo notebooks for Python projects
 meta_title: Marimo notebooks for Python projects
 description: Why marimo is an interesting notebook alternative for Python projects.
 date: 2026-04-15
-writingDate: 2026-03-27
+writing_date: 2026-03-27
 image: /images/blog/0067-marimo.jpg
 category: tools
 tags: [Python, Tools, AWS, DE]

--- a/src/content/blog/0068-be-nice-data.mdx
+++ b/src/content/blog/0068-be-nice-data.mdx
@@ -4,7 +4,7 @@ title: How to Be Nice to the Data Team
 meta_title: How to Be Nice to the Data Team
 description: A practical guide for product, engineering, ops, and business teams on how to design source systems and frame requests so the data team can deliver faster and more reliably.
 date: 2026-05-05
-writingDate: 2026-05-05
+writing_date: 2026-05-05
 image: /images/blog/0068-traffic-police.jpg
 category: DE
 tags: [Data Engineering, Best Practices]

--- a/src/content/blog/0068-be-nice-data.mdx
+++ b/src/content/blog/0068-be-nice-data.mdx
@@ -4,6 +4,7 @@ title: How to Be Nice to the Data Team
 meta_title: How to Be Nice to the Data Team
 description: A practical guide for product, engineering, ops, and business teams on how to design source systems and frame requests so the data team can deliver faster and more reliably.
 date: 2026-05-05
+writingDate: 2026-05-05
 image: /images/blog/0068-traffic-police.jpg
 category: DE
 tags: [Data Engineering, Best Practices]

--- a/src/content/blog/0069-one-environment-prod.mdx
+++ b/src/content/blog/0069-one-environment-prod.mdx
@@ -4,6 +4,7 @@ title: One Environment to Rule Them All
 meta_title: One Environment to Rule Them All - Rethinking Dev, Test, and Prod
 description: Do we really need dev, test, and sandbox? Explore the case for a single prod environment, how dbt handles it, how to run Python this way, and the pros and cons of going prod-only.
 date: 2026-06-10
+writingDate: 2025-09-03
 image: /images/blog/0069-glass-bridge.jpg
 category: DE
 tags: [Python, dbt, DE, Environments]

--- a/src/content/blog/0069-one-environment-prod.mdx
+++ b/src/content/blog/0069-one-environment-prod.mdx
@@ -4,7 +4,7 @@ title: One Environment to Rule Them All
 meta_title: One Environment to Rule Them All - Rethinking Dev, Test, and Prod
 description: Do we really need dev, test, and sandbox? Explore the case for a single prod environment, how dbt handles it, how to run Python this way, and the pros and cons of going prod-only.
 date: 2026-06-10
-writingDate: 2025-09-03
+writing_date: 2025-09-03
 image: /images/blog/0069-glass-bridge.jpg
 category: DE
 tags: [Python, dbt, DE, Environments]

--- a/src/content/blog/0070-qlik-api.mdx
+++ b/src/content/blog/0070-qlik-api.mdx
@@ -4,6 +4,7 @@ title: Querying Qlik API with Python
 meta_title: Querying Qlik API with Python
 description: A practical, step-by-step guide to building a minimal synchronous Python client for Qlik Cloud—covering authentication, pagination, metadata, reloads, polling, and retries.
 date: 2026-07-14
+writingDate: 2025-10-03
 image: /images/blog/0070-qlik-magnifying-glass-showing-the-way.jpg
 category: API
 tags: [Python, API, Data Engineering, Best Practices]

--- a/src/content/blog/0070-qlik-api.mdx
+++ b/src/content/blog/0070-qlik-api.mdx
@@ -4,7 +4,7 @@ title: Querying Qlik API with Python
 meta_title: Querying Qlik API with Python
 description: A practical, step-by-step guide to building a minimal synchronous Python client for Qlik Cloud—covering authentication, pagination, metadata, reloads, polling, and retries.
 date: 2026-07-14
-writingDate: 2025-10-03
+writing_date: 2025-10-03
 image: /images/blog/0070-qlik-magnifying-glass-showing-the-way.jpg
 category: API
 tags: [Python, API, Data Engineering, Best Practices]

--- a/src/content/blog/0071-qlik-async.mdx
+++ b/src/content/blog/0071-qlik-async.mdx
@@ -4,6 +4,7 @@ title: "Async APIs with Python: Scaling Qlik Queries"
 meta_title: "Async APIs with Python: Scaling Qlik Queries"
 description: Learn how to scale Qlik Cloud automation with Python’s asyncio and aiohttp. This post builds an async client for concurrent reloads, pagination, retries, and error handling.
 date: 2025-10-07
+writingDate: 2026-07-17
 image: /images/blog/0071-dangerous-qlik-magnifying-glass.jpg
 category: API
 tags: [Python, API, AsyncIO, Data Engineering]

--- a/src/content/blog/0071-qlik-async.mdx
+++ b/src/content/blog/0071-qlik-async.mdx
@@ -4,7 +4,7 @@ title: "Async APIs with Python: Scaling Qlik Queries"
 meta_title: "Async APIs with Python: Scaling Qlik Queries"
 description: Learn how to scale Qlik Cloud automation with Python’s asyncio and aiohttp. This post builds an async client for concurrent reloads, pagination, retries, and error handling.
 date: 2025-10-07
-writingDate: 2026-07-17
+writing_date: 2026-07-17
 image: /images/blog/0071-dangerous-qlik-magnifying-glass.jpg
 category: API
 tags: [Python, API, AsyncIO, Data Engineering]

--- a/src/content/blog/0071-qlik-async.mdx
+++ b/src/content/blog/0071-qlik-async.mdx
@@ -4,7 +4,7 @@ title: "Async APIs with Python: Scaling Qlik Queries"
 meta_title: "Async APIs with Python: Scaling Qlik Queries"
 description: Learn how to scale Qlik Cloud automation with Python’s asyncio and aiohttp. This post builds an async client for concurrent reloads, pagination, retries, and error handling.
 date: 2025-10-07
-writing_date: 2026-07-17
+writing_date: 2025-10-07
 image: /images/blog/0071-dangerous-qlik-magnifying-glass.jpg
 category: API
 tags: [Python, API, AsyncIO, Data Engineering]

--- a/src/content/blog/9999-agents-setup.mdx
+++ b/src/content/blog/9999-agents-setup.mdx
@@ -4,7 +4,7 @@ title: A Multi-Agent Setup That Learns
 meta_title: A Multi-Agent Setup That Learns - Shared Skills, Committed Lessons, Plan-First Workflow
 description: How I set up AI coding agents across multiple data repos so any agent (Claude, Codex, ...) shares the same instructions, skills live in one versioned repo consumed as a git submodule, corrections become committed rules or pre-commit hooks instead of private memory, and every task starts with a written plan that survives lost sessions.
 date: 2026-07-17
-writingDate: 2026-07-17
+writing_date: 2026-07-17
 image: /images/blog/9999-f1-pit-stop-agents.jpg
 category: DE
 tags: [DE, AI, Best Practices]

--- a/src/content/blog/9999-agents-setup.mdx
+++ b/src/content/blog/9999-agents-setup.mdx
@@ -4,6 +4,7 @@ title: A Multi-Agent Setup That Learns
 meta_title: A Multi-Agent Setup That Learns - Shared Skills, Committed Lessons, Plan-First Workflow
 description: How I set up AI coding agents across multiple data repos so any agent (Claude, Codex, ...) shares the same instructions, skills live in one versioned repo consumed as a git submodule, corrections become committed rules or pre-commit hooks instead of private memory, and every task starts with a written plan that survives lost sessions.
 date: 2026-07-17
+writingDate: 2026-07-17
 image: /images/blog/9999-f1-pit-stop-agents.jpg
 category: DE
 tags: [DE, AI, Best Practices]

--- a/src/content/blog/9999-de-hero-agent-stage-1.mdx
+++ b/src/content/blog/9999-de-hero-agent-stage-1.mdx
@@ -4,7 +4,7 @@ title: The Hero Agent, Stage 1 - Structured Failure Triage
 meta_title: Building a Data Engineering Hero Agent - Stage 1 Ingestion and Alerting
 description: A hands-on walkthrough of Stage 1 of the DE hero agent - a FastAPI service that ingests structured failure events, deduplicates Prefect-vs-ECS alerts, and posts clean Slack messages while failing safe.
 date: 2026-07-07
-writing_date: 2026-07-17
+writing_date: 2026-07-07
 image: /images/blog/9999-de-hero-agent-stage-1.jpg
 category: DE
 tags: [DE, Python, FastAPI, Prefect, Best Practices]

--- a/src/content/blog/9999-de-hero-agent-stage-1.mdx
+++ b/src/content/blog/9999-de-hero-agent-stage-1.mdx
@@ -4,7 +4,7 @@ title: The Hero Agent, Stage 1 - Structured Failure Triage
 meta_title: Building a Data Engineering Hero Agent - Stage 1 Ingestion and Alerting
 description: A hands-on walkthrough of Stage 1 of the DE hero agent - a FastAPI service that ingests structured failure events, deduplicates Prefect-vs-ECS alerts, and posts clean Slack messages while failing safe.
 date: 2026-07-07
-writingDate: 2026-07-17
+writing_date: 2026-07-17
 image: /images/blog/9999-de-hero-agent-stage-1.jpg
 category: DE
 tags: [DE, Python, FastAPI, Prefect, Best Practices]

--- a/src/content/blog/9999-de-hero-agent-stage-1.mdx
+++ b/src/content/blog/9999-de-hero-agent-stage-1.mdx
@@ -4,6 +4,7 @@ title: The Hero Agent, Stage 1 - Structured Failure Triage
 meta_title: Building a Data Engineering Hero Agent - Stage 1 Ingestion and Alerting
 description: A hands-on walkthrough of Stage 1 of the DE hero agent - a FastAPI service that ingests structured failure events, deduplicates Prefect-vs-ECS alerts, and posts clean Slack messages while failing safe.
 date: 2026-07-07
+writingDate: 2026-07-17
 image: /images/blog/9999-de-hero-agent-stage-1.jpg
 category: DE
 tags: [DE, Python, FastAPI, Prefect, Best Practices]

--- a/src/content/blog/9999-de-hero-agent-vision.mdx
+++ b/src/content/blog/9999-de-hero-agent-vision.mdx
@@ -4,7 +4,7 @@ title: Building a Data Engineering Hero Agent
 meta_title: Building a Data Engineering Hero Agent - From Manual Triage to Autonomy
 description: The vision behind a service that automates the on-call "hero" work in data engineering. Why I want to centralize failure handling, how the model earns the right to act on its own, and how the system is designed to gain autonomy in stages.
 date: 2026-07-07
-writingDate: 2026-07-17
+writing_date: 2026-07-17
 image: /images/blog/9999-hero-agent-firefighter-europe.jpg
 category: DE
 tags: [DE, AI, Best Practices, Prefect]

--- a/src/content/blog/9999-de-hero-agent-vision.mdx
+++ b/src/content/blog/9999-de-hero-agent-vision.mdx
@@ -4,6 +4,7 @@ title: Building a Data Engineering Hero Agent
 meta_title: Building a Data Engineering Hero Agent - From Manual Triage to Autonomy
 description: The vision behind a service that automates the on-call "hero" work in data engineering. Why I want to centralize failure handling, how the model earns the right to act on its own, and how the system is designed to gain autonomy in stages.
 date: 2026-07-07
+writingDate: 2026-07-17
 image: /images/blog/9999-hero-agent-firefighter-europe.jpg
 category: DE
 tags: [DE, AI, Best Practices, Prefect]

--- a/src/content/blog/9999-de-hero-agent-vision.mdx
+++ b/src/content/blog/9999-de-hero-agent-vision.mdx
@@ -4,7 +4,7 @@ title: Building a Data Engineering Hero Agent
 meta_title: Building a Data Engineering Hero Agent - From Manual Triage to Autonomy
 description: The vision behind a service that automates the on-call "hero" work in data engineering. Why I want to centralize failure handling, how the model earns the right to act on its own, and how the system is designed to gain autonomy in stages.
 date: 2026-07-07
-writing_date: 2026-07-17
+writing_date: 2026-07-07
 image: /images/blog/9999-hero-agent-firefighter-europe.jpg
 category: DE
 tags: [DE, AI, Best Practices, Prefect]

--- a/src/content/blog/9999-query-analysis.mdx
+++ b/src/content/blog/9999-query-analysis.mdx
@@ -4,7 +4,7 @@ title: Static Query Analysis with Sqlglot
 meta_title: Static SQL Query Analysis with Sqlglot for Data Engineering
 description: Learn how to perform static query analysis using Sqlglot to extract query structure, joins, and performance indicators without executing SQL.
 date: 2025-10-14
-writingDate: 2026-07-17
+writing_date: 2026-07-17
 image: /images/blog/9999-query-tree.jpg
 category: DE
 tags: [SQL, DE, sqlglot, Performance, Analytics]

--- a/src/content/blog/9999-query-analysis.mdx
+++ b/src/content/blog/9999-query-analysis.mdx
@@ -4,6 +4,7 @@ title: Static Query Analysis with Sqlglot
 meta_title: Static SQL Query Analysis with Sqlglot for Data Engineering
 description: Learn how to perform static query analysis using Sqlglot to extract query structure, joins, and performance indicators without executing SQL.
 date: 2025-10-14
+writingDate: 2026-07-17
 image: /images/blog/9999-query-tree.jpg
 category: DE
 tags: [SQL, DE, sqlglot, Performance, Analytics]

--- a/src/content/blog/9999-query-analysis.mdx
+++ b/src/content/blog/9999-query-analysis.mdx
@@ -4,7 +4,7 @@ title: Static Query Analysis with Sqlglot
 meta_title: Static SQL Query Analysis with Sqlglot for Data Engineering
 description: Learn how to perform static query analysis using Sqlglot to extract query structure, joins, and performance indicators without executing SQL.
 date: 2025-10-14
-writing_date: 2026-07-17
+writing_date: 2025-10-14
 image: /images/blog/9999-query-tree.jpg
 category: DE
 tags: [SQL, DE, sqlglot, Performance, Analytics]

--- a/src/pages/blog/[single].astro
+++ b/src/pages/blog/[single].astro
@@ -21,7 +21,7 @@ export async function getStaticPaths() {
 
 const { post } = Astro.props;
 const { blog_folder, similar_items_length } = config.settings;
-const { title, description, image, date, updatedDate, tags = [], category } = post.data;
+const { title, description, image, date, updated_date: updatedDate, tags = [], category } = post.data;
 const slug     = post.data.slug || post.id;
 const canonical = `${config.site.base_url}${Astro.url.pathname}`;
 


### PR DESCRIPTION
## Summary
- Add `writing_date` (internal, never rendered) and rename `updatedDate` → `updated_date` (rendered as "Updated …") in the blog frontmatter schema
- Backfill both dates for all 75 posts from git history:
  - `writing_date`: earliest commit that added the post, traced across renames/renumbering (including pre-Astro yaml/md incarnations and `9999-*` drafts)
  - `updated_date`: last real post-publication edit — commits touching few posts, or 10+ changed lines in a medium batch; migrations, renumbering and dep bumps excluded
- Drafts keep their tentative `date` as `writing_date`

🤖 Generated with [Claude Code](https://claude.com/claude-code)