### PR TITLE
Skip Netlify Deploy Previews for Dependabot branches

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,11 @@
 [build]
 command = "npm ci && npm run build"
 publish = "dist"
+# Skip Deploy Previews for Dependabot branches: GitHub Actions already runs
+# `npm run build`, and there's nothing to eyeball on a dependency bump. The
+# ignore command exits 0 (skip build) for dependabot/* branches, non-zero
+# (build) otherwise, so content/feature PRs still get previews.
+ignore = "bash -c '[ \"${HEAD%%/*}\" = dependabot ]'"
 
 # Security headers
 [[headers]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "villoro",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "villoro",
-      "version": "3.2.7",
+      "version": "3.2.8",
       "license": "MIT",
       "dependencies": {
         "@astrojs/markdown-remark": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "villoro",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "description": "My personal website",
   "author": "Arnau Villoro <arnau@villoro.com>",
   "license": "MIT",


### PR DESCRIPTION
## Problem
Dependabot PRs each trigger a full ~8-min Netlify Deploy Preview build, eating build-minute quota.

## Fix
Add a netlify.toml `ignore` command that skips the build for `dependabot/*` branches. Exits `0` (skip) when the branch name up to the first `/` is `dependabot`, non-zero (build) otherwise — so content/feature PR previews are unaffected.

## Why this is safe
- GitHub Actions already runs `npm run build` on every PR (the `bundle_size` job), so a bump that breaks the build is still caught.
- There's nothing to visually review on a dependency bump, so the preview URL had no value there.
- Security patches keep flowing; only the redundant preview build is skipped.

Does **not** touch the underlying ~8-min build time — that's a separate, larger issue for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)