### PR TITLE
Protect main from direct pushes in no-commit-to-branch hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       - id: check-toml
       - id: check-merge-conflict
       - id: no-commit-to-branch
+        args: ['--branch', 'main']
 
   # YAML formatter
   - repo: https://github.com/google/yamlfmt

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "villoro",
-  "version": "3.2.10",
+  "version": "3.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "villoro",
-      "version": "3.2.10",
+      "version": "3.2.11",
       "license": "MIT",
       "dependencies": {
         "@astrojs/markdown-remark": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "villoro",
-  "version": "3.2.10",
+  "version": "3.2.11",
   "description": "My personal website",
   "author": "Arnau Villoro <arnau@villoro.com>",
   "license": "MIT",


### PR DESCRIPTION
The `no-commit-to-branch` hook had no args, so it only protected `master` by default, not this repo's `main`. Also migrated branch protection to a Ruleset that blocks direct pushes to `main`, with a scoped admin bypass for merging via PR.